### PR TITLE
switch to dev for preview environment deploys

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -7,15 +7,15 @@ on:
             - '**'
 
 jobs:
-    delete_qa_deployment:
-        name: Delete qa preview deployment
+    delete_dev_deployment:
+        name: Delete dev preview deployment
         runs-on: ubuntu-latest
         environment:
-            name: qa-preview
+            name: dev-preview
             url: ''
         steps:
             - name: Close pull request
               uses: Azure/static-web-apps-deploy@v1
               with:
-                  azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_QA }}
+                  azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DEV }}
                   action: close

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -31,12 +31,12 @@ jobs:
     # This will deploy to a "preview environment" in Azure Static Web Apps
     # which means each PR will get its own environment. This means multiple PRs
     # can be tested at the same time.
-    deploy_to_qa:
-        name: Deploy to qa
+    deploy_to_dev_preview:
+        name: Deploy to dev preview
         runs-on: ubuntu-latest
         needs: lint_and_test
         environment:
-            name: qa-preview
+            name: dev-preview
             url: ${{ steps.deploy.outputs.deployed-url }}
         steps:
             - name: Checkout source code
@@ -46,5 +46,5 @@ jobs:
             - uses: ./.github/actions/build-and-deploy-to-env
               id: deploy
               with:
-                  environment: qa
-                  api-token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_QA }}
+                  environment: dev
+                  api-token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DEV }}


### PR DESCRIPTION
In order to keep QA env locked down more (to mimic prod) we're opening up the CORS on dev and using dev for our preview deployments.