### PR TITLE
Add Origin Header if Fetch From Server

### DIFF
--- a/src/lib/utils/http-service.ts
+++ b/src/lib/utils/http-service.ts
@@ -1,4 +1,5 @@
 import config from '$lib/config';
+import { browser } from '$app/environment';
 
 const API_KEY = config.PUBLIC_AQUIFER_API_KEY;
 
@@ -11,6 +12,10 @@ export async function fetchWrapper(url: string, options: FetchOptions = {}): Pro
 
     if (!options.headers['api-key']) {
         options.headers['api-key'] = API_KEY;
+    }
+
+    if (!browser) {
+        options.headers['Origin'] = 'aquifer-admin';
     }
 
     options.method = options.method || 'GET';


### PR DESCRIPTION
Because of the weak security I have on the front end API keys, where it looks for specific origins if using the key, requests that originate from the server will fail. This adds a default origin header that can be checked from APIM.