### PR TITLE
standardize resource status enums and pull from API

### DIFF
--- a/src/lib/components/resources/Process.svelte
+++ b/src/lib/components/resources/Process.svelte
@@ -2,29 +2,19 @@
     import Accordion from './Accordion.svelte';
     import { Icon } from 'svelte-awesome';
     import volumeUp from 'svelte-awesome/icons/volumeUp';
-    import { ResourceStatusEnum } from '$lib/types/resources';
     import { setOriginalValues, updateValues } from '$lib/stores/tiptapContent';
     import { canEdit } from '$lib/stores/auth';
+    import { _ as translate } from 'svelte-i18n';
+    import type { ResourceContentStatus, ResourceContentStatusEnum } from '$lib/types/base';
     import type { ResourceContentAssignedUser } from '$lib/types/resources';
 
-    export let translationStatus: ResourceStatusEnum;
+    export let translationStatus: ResourceContentStatusEnum;
     export let hasAudio: boolean;
     export let assignedUser: ResourceContentAssignedUser | null;
+    export let resourceContentStatuses: ResourceContentStatus[];
 
     setOriginalValues({ status: translationStatus });
     $: updateValues({ status: translationStatus });
-
-    const translationStatusOptions = [
-        { value: ResourceStatusEnum.AquiferizeNotStarted, name: 'Aquiferize - Not Started' },
-        { value: ResourceStatusEnum.AquiferizeInProgress, name: 'Aquiferize - In Progress' },
-        { value: ResourceStatusEnum.Complete, name: 'Complete' },
-        { value: ResourceStatusEnum.AquiferizeInReview, name: 'Aquiferize - In Review' },
-        { value: ResourceStatusEnum.TranslateNotStarted, name: 'Translate - Not Started' },
-        { value: ResourceStatusEnum.TranslateDrafting, name: 'Translate - Drafting' },
-        { value: ResourceStatusEnum.TranslateEditing, name: 'Translate - Editing' },
-        { value: ResourceStatusEnum.TranslateReviewing, name: 'Translate - Reviewing' },
-        { value: ResourceStatusEnum.OnHold, name: 'On Hold' },
-    ] as { value: ResourceStatusEnum; name: string }[];
 </script>
 
 <Accordion title="Process" closable={true}>
@@ -34,12 +24,13 @@
                 <div class="me-2 font-bold">Status</div>
                 {#if $canEdit}
                     <select bind:value={translationStatus} class="select select-ghost select-sm me-2 max-w-xs">
-                        {#each translationStatusOptions as status}
-                            <option value={status.value}>{status.name}</option>
+                        {#each resourceContentStatuses as { status, displayName }}
+                            <option value={status}>{displayName}</option>
                         {/each}
                     </select>
                 {:else}
-                    {translationStatusOptions.find((x) => x.value === translationStatus)?.name}
+                    {resourceContentStatuses.find((x) => x.status === translationStatus)?.displayName ??
+                        $translate('page.resources.table.statuses.none.value')}
                 {/if}
             </div>
             <div class="mb-4 flex justify-between">

--- a/src/lib/i18n/locales/eng.json
+++ b/src/lib/i18n/locales/eng.json
@@ -73,18 +73,6 @@
                     "_context": "The table header for the resource status column"
                 },
                 "statuses": {
-                    "notStarted": {
-                        "value": "Pending",
-                        "_context": "Label for the Not Started resource status"
-                    },
-                    "inProgress": {
-                        "value": "In Progress",
-                        "_context": "Label for the In Progress resource status"
-                    },
-                    "completed": {
-                        "value": "Aquiferized",
-                        "_context": "Label for the Completed resource status"
-                    },
                     "none": {
                         "value": "Not Applicable",
                         "_context": "Label for the None resource status"

--- a/src/lib/stores/tiptapContent.ts
+++ b/src/lib/stores/tiptapContent.ts
@@ -1,5 +1,6 @@
 ﻿import { type Writable, writable, get } from 'svelte/store';
 import type { JSONContent } from '@tiptap/core';
+import type { ResourceContentStatusEnum } from '$lib/types/base';
 
 export const originalValues: Writable<TiptapContentValues> = writable({
     contentId: undefined,
@@ -40,7 +41,7 @@ interface TiptapContentValues {
     contentId?: number | undefined;
     content?: TiptapContentItemValues[] | undefined;
     displayName?: string | undefined;
-    status?: string | undefined;
+    status?: ResourceContentStatusEnum | undefined;
 }
 
 export interface TiptapContentItemValues {

--- a/src/lib/types/base.ts
+++ b/src/lib/types/base.ts
@@ -1,8 +1,30 @@
+import type { ValuesOf } from '@tiptap/core';
+
 export interface ResourceType {
     id: number;
     displayName: string;
     complexityLevel: string;
 }
+
+export interface ResourceContentStatus {
+    status: ResourceContentStatusEnum;
+    displayName: string;
+}
+
+export const ResourceContentStatusValues = {
+    None: 'None',
+    AquiferizeNotStarted: 'AquiferizeNotStarted',
+    AquiferizeInProgress: 'AquiferizeInProgress',
+    Complete: 'Complete',
+    AquiferizeInReview: 'AquiferizeInReview',
+    TranslateNotStarted: 'TranslateNotStarted',
+    TranslateDrafting: 'TranslateDrafting',
+    TranslateEditing: 'TranslateEditing',
+    TranslateReviewing: 'TranslateReviewing',
+    OnHold: 'OnHold',
+} as const;
+
+export type ResourceContentStatusEnum = ValuesOf<typeof ResourceContentStatusValues>;
 
 export interface Language {
     id: number;

--- a/src/lib/types/resources.ts
+++ b/src/lib/types/resources.ts
@@ -1,3 +1,5 @@
+import type { ResourceContentStatusEnum } from './base';
+
 export enum ResourceTypeEnum {
     cbbterTranslationGuide = 'Translation Guide (SRV)',
     tyndaleBibleDictionary = 'Bible Dictionary (Tyndale)',
@@ -11,19 +13,6 @@ export enum MediaTypeEnum {
     video = 'Video',
     image = 'Image',
     text = 'Text',
-}
-
-export enum ResourceStatusEnum {
-    AquiferizeNotStarted = 'AquiferizeNotStarted',
-    AquiferizeInProgress = 'AquiferizeInProgress',
-    Complete = 'Complete',
-    AquiferizeInReview = 'AquiferizeInReview',
-    TranslateNotStarted = 'TranslateNotStarted',
-    TranslateDrafting = 'TranslateDrafting',
-    TranslateEditing = 'TranslateEditing',
-    TranslateReviewing = 'TranslateReviewing',
-    OnHold = 'OnHold',
-    None = 'None',
 }
 
 export interface PassageReference {
@@ -107,7 +96,7 @@ export interface ResourceContent {
     resourceContentId: number;
     displayName: string;
     mediaType: string;
-    status: ResourceStatusEnum;
+    status: ResourceContentStatusEnum;
     contentSize: number;
     language: Language;
     content: ContentItem | ContentItem[];

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -2,16 +2,22 @@ import type { LayoutLoad } from './$types';
 import { waitLocale } from 'svelte-i18n';
 import { initI18n } from '$lib/i18n';
 import { fetchJsonFromApi } from '$lib/utils/http-service';
-import type { Language, ResourceType } from '$lib/types/base';
+import type { Language, ResourceContentStatus, ResourceType } from '$lib/types/base';
 
 export const load: LayoutLoad = async ({ fetch }) => {
-    const [languages, resourceTypes] = await Promise.all([getLanguages(fetch), getResourceTypes(fetch), initI18n()]);
+    const [languages, resourceTypes, resourceContentStatuses] = await Promise.all([
+        getLanguages(fetch),
+        getResourceTypes(fetch),
+        getResourceContentStatuses(fetch),
+        initI18n(),
+    ]);
 
     await waitLocale();
 
     return {
         languages,
         resourceTypes,
+        resourceContentStatuses,
     };
 };
 
@@ -21,4 +27,8 @@ async function getLanguages(fetch: typeof window.fetch) {
 
 async function getResourceTypes(fetch: typeof window.fetch) {
     return (await fetchJsonFromApi('/resources/parent-resources', {}, fetch)) as ResourceType[];
+}
+
+async function getResourceContentStatuses(fetch: typeof window.fetch) {
+    return (await fetchJsonFromApi('/resources/content/statuses', {}, fetch)) as ResourceContentStatus[];
 }

--- a/src/routes/resources/+page.ts
+++ b/src/routes/resources/+page.ts
@@ -2,6 +2,7 @@ import type { PageLoad } from './$types';
 import { fetchJsonStreamingFromApi } from '$lib/utils/http-service';
 import { createSearchParamStore } from '$lib/utils/search-params';
 import { get } from 'svelte/store';
+import type { ResourceContentStatusEnum } from '$lib/types/base';
 
 export const load: PageLoad = async ({ url, fetch }) => {
     const currentPage = createSearchParamStore(url, 'page', 1);
@@ -66,6 +67,6 @@ export interface ResourceListItem {
     id: number;
     englishLabel: string;
     parentResourceName: string;
-    status: string;
+    status: ResourceContentStatusEnum;
     contentIdsWithLanguageIds: ResourceListItemContentIdWithLanguageId[];
 }

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -124,6 +124,7 @@
                     translationStatus={resourceContent.status}
                     hasAudio={resourceContent.hasAudio}
                     assignedUser={resourceContent.assignedUser}
+                    resourceContentStatuses={data.resourceContentStatuses}
                 />
                 <RelatedContent relatedContent={resourceContent.associatedResources} />
                 <BibleReferences bibleReferences={resourceContent.passageReferences} />


### PR DESCRIPTION
This fixes the resource list (which had broken statuses since the API changes) and moves away from having translated resource status strings toward using the API resource status display names so we're just declaring them in one place.