### PR TITLE
add step to auth initialization to check if refresh token is valid

### DIFF
--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -45,6 +45,7 @@ export const initAuth0 = async () => {
 
     if (isAuthenticated) {
         try {
+            await client.getTokenSilently(); // ensure refresh token is valid (throws error if not)
             profile.set(await client.getUser());
             authenticated.set(isAuthenticated);
         } catch (error) {

--- a/src/lib/utils/http-service.ts
+++ b/src/lib/utils/http-service.ts
@@ -102,9 +102,6 @@ export async function fetchJsonFromApi(
     injectedFetch: typeof window.fetch | undefined = undefined
 ): Promise<unknown> {
     const response = await fetchFromApi(path, options, injectedFetch);
-    if (response.status >= 400) {
-        throw error(response.status, `HTTP response: ${response.status}`);
-    }
     try {
         return await response.json();
     } catch {
@@ -125,5 +122,9 @@ export async function fetchFromApi(
 
     const url = BASE_URL + '/' + (path.startsWith('/') ? path.slice(1) : path);
 
-    return (injectedFetch || fetch)(url, options);
+    const response = await (injectedFetch || fetch)(url, options);
+    if (response.status >= 400) {
+        throw error(response.status, `HTTP response: ${response.status}`);
+    }
+    return response;
 }

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -43,17 +43,19 @@
     let isSaving = false;
     const onSave = async () => {
         isSaving = true;
-        await putData();
-        isSaving = false;
+        try {
+            await putData();
+        } finally {
+            isSaving = false;
+        }
     };
 
     const onSaveAndCloseClick = async () => {
         loadingModal.showModal();
-        const response = await putData();
-
-        if (response.status === 204) {
+        try {
+            await putData();
             goBack();
-        } else {
+        } catch {
             loadingModal.close();
         }
     };
@@ -63,27 +65,26 @@
     };
 
     const putData = async () => {
-        const token = await $auth0Client?.getTokenSilently();
-        const response = await fetchFromApi(`/resources/content/summary/${$updatedValues.contentId}`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`,
-            },
-            body: JSON.stringify({
-                status: $updatedValues.status,
-                displayName: $updatedValues.displayName,
-                content: $updatedValues.content,
-            }),
-        });
+        try {
+            const token = await $auth0Client?.getTokenSilently();
+            await fetchFromApi(`/resources/content/summary/${$updatedValues.contentId}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                    status: $updatedValues.status,
+                    displayName: $updatedValues.displayName,
+                    content: $updatedValues.content,
+                }),
+            });
 
-        if (response.status === 204) {
             updateOriginal();
-        } else {
+        } catch (error) {
             errorModal.showModal();
+            throw error;
         }
-
-        return response;
     };
 </script>
 


### PR DESCRIPTION
When using `localstorage` mode for Auth0, it doesn't have an expiration time the same way that a
cookie would. Also, the `isAuthenticated()` will still return true if the token exists (even if it's
expired). Because of this, to ensure that the refresh token we have in localstorage is still valid,
we need to call `getTokenSilently` when initializing the auth. If it fails then we know the token
has expired and the user needs to log in again.

This also adds error handling to the resource edit page for if the token is expired. This shouldn't
be a common case now but it could still happen if the user loaded the application before expiration
but the token expired while they were using it.

We probably need to add some sort of pattern with maybe a global modal that would show a specific
error for if the session is expired, and ask the user to log back in.
