### PR TITLE
fetch the current user at the root layout level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ vite.config.ts.timestamp-*
 /dev-dist/
 /tmp/
 yarn-error.log
-.env.local
+/.env.local
+!/config/.env.local

--- a/config/.env.local
+++ b/config/.env.local
@@ -1,8 +1,8 @@
 # IMPORTANT: do not put anything sensitive in this file
 
-PUBLIC_ENV="local"
+PUBLIC_AQUIFER_API_KEY=""
 PUBLIC_AQUIFER_API_URL="http://localhost:5257"
-PUBLIC_AUTH0_DOMAIN="dev-bjm6e3tp0dti2618.us.auth0.com"
-PUBLIC_AUTH0_CLIENT_ID="CoUeKLcerxX7FPGeu1S309p0JXC6cSPe"
 PUBLIC_AUTH0_AUDIENCE="aquifer-server-dev.azurewebsites.net"
-PUBLIC_AQUIFER_API_KEY="8b55d5dbb4dd4cd5a7d1e85d6d6d738b"
+PUBLIC_AUTH0_CLIENT_ID="CoUeKLcerxX7FPGeu1S309p0JXC6cSPe"
+PUBLIC_AUTH0_DOMAIN="dev-bjm6e3tp0dti2618.us.auth0.com"
+PUBLIC_ENV="local"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.2",
         "@microsoft/applicationinsights-web": "^3.0.2",
-        "@sveltejs/kit": "^1.20.4",
+        "@sveltejs/kit": "^1.29.1",
         "@tailwindcss/typography": "^0.5.9",
         "@tiptap/core": "^2.1.12",
         "@tiptap/extension-highlight": "^2.1.12",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -18,12 +18,16 @@ export const handle: Handle = async ({ event, resolve }) => {
     });
 };
 
-export const handleFetch: HandleFetch = async ({ request, fetch }) => {
-    const headers = new Headers(request.headers);
-    headers.set('api-key', config.PUBLIC_AQUIFER_API_KEY);
-    const newRequest = new Request(request, { headers });
+export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
+    // only add auth info to Aquifer requests (prevents leaking credentials if we ever fetch from other APIs)
+    if (request.url.startsWith(config.PUBLIC_AQUIFER_API_URL)) {
+        const authToken = event.cookies.get('AuthToken');
+        if (authToken) {
+            request.headers.set('Authorization', `Bearer ${authToken}`);
+        }
+    }
 
-    return fetch(newRequest);
+    return fetch(request);
 };
 
 export const handleError = (async ({ error }: { error: Error }) => {

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -1,28 +1,33 @@
-﻿import { type Writable, writable, get } from 'svelte/store';
+﻿import { type Writable, writable, derived, get } from 'svelte/store';
 import { Auth0Client, createAuth0Client, User } from '@auth0/auth0-spa-js';
 import config from '$lib/config';
 import { goto } from '$app/navigation';
 import { log } from '$lib/logger';
+import { dev } from '$app/environment';
 
 export const auth0Client: Writable<Auth0Client | undefined> = writable(undefined);
 export const profile: Writable<User | undefined> = writable(undefined);
 export const authenticated: Writable<boolean> = writable(false);
-export const canEdit: Writable<boolean> = writable(false);
+export const authz = derived([profile], ([user]) => {
+    return {
+        hasRole: (role: Role) => user?.bnRoles?.includes(role) === true,
+    };
+});
+export const canEdit = derived([profile], ([user]) => {
+    return (user?.bnRoles?.includes('admin') || user?.bnRoles?.includes('editor')) === true;
+});
 const auth0Domain = config.PUBLIC_AUTH0_DOMAIN;
 const auth0ClientId = config.PUBLIC_AUTH0_CLIENT_ID;
 const auth0Audience = config.PUBLIC_AUTH0_AUDIENCE;
-const editorRoles = ['admin', 'editor'];
 
-profile.subscribe((user) => {
-    canEdit.set(editorRoles.some((role) => user?.bnRoles.includes(role)));
-});
+export enum Role {
+    Publisher = 'publisher',
+    Admin = 'admin',
+    Editor = 'editor',
+    Manager = 'manager',
+}
 
-let currentUrl: URL;
-export const setCurrentPageUrl = (url: URL) => {
-    currentUrl = url;
-};
-
-export const initAuth0 = async () => {
+export async function initAuth0(url: URL) {
     const client = await createAuth0Client({
         domain: auth0Domain,
         clientId: auth0ClientId,
@@ -37,7 +42,7 @@ export const initAuth0 = async () => {
 
     let isAuthenticated = await client.isAuthenticated();
 
-    if (!isAuthenticated && currentUrl.searchParams.has('code') && currentUrl.searchParams.has('state')) {
+    if (!isAuthenticated && url.searchParams.has('code') && url.searchParams.has('state')) {
         await client.handleRedirectCallback();
         await goto('/');
         isAuthenticated = await client.isAuthenticated();
@@ -45,33 +50,75 @@ export const initAuth0 = async () => {
 
     if (isAuthenticated) {
         try {
-            await client.getTokenSilently(); // ensure refresh token is valid (throws error if not)
+            // set cookie and ensure refresh token is valid (throws error if not)
+            await syncAuthTokenToCookies(client);
+
             profile.set(await client.getUser());
             authenticated.set(isAuthenticated);
         } catch (error) {
             log.exception(error as Error);
-            await logout();
+            await logout(url);
         }
     } else {
         authenticated.set(false);
-        await login();
+        await login(url);
     }
-};
+}
 
-const login = async () => {
+export async function syncAuthTokenToCookies(client: Auth0Client | undefined) {
+    if (client) {
+        const authToken = await client.getTokenSilently();
+
+        // set an AuthToken cookie so that SSR requests receive a cookie that can be used against the API
+        setCookie('AuthToken', authToken, {
+            path: '/',
+            sameSite: 'strict',
+            expires: getJwtExpiration(authToken),
+            secure: !dev,
+        });
+    }
+}
+
+async function login(url: URL) {
     await get(auth0Client)?.loginWithRedirect({
         authorizationParams: {
-            redirect_uri: currentUrl.href,
+            redirect_uri: url.href,
         },
     });
-};
+}
 
-export const logout = async () => {
+export async function logout(url: URL) {
     profile.set(undefined);
     authenticated.set(false);
     await get(auth0Client)?.logout({
         logoutParams: {
-            returnTo: currentUrl.origin,
+            returnTo: url.origin,
         },
     });
-};
+}
+
+function setCookie(
+    name: string,
+    value: string,
+    options: { expires?: number; path?: string; sameSite?: string; secure?: boolean } = {}
+) {
+    let cookie = `${name}=${value};`;
+
+    if (options.expires) {
+        const date = new Date();
+        date.setTime(options.expires * 1000);
+        cookie += ` expires=${date.toUTCString()};`;
+    }
+
+    cookie += ` path=${options.path || '/'};`;
+    if (options.sameSite) cookie += ` SameSite=${options.sameSite};`;
+    if (options.secure) cookie += ` Secure;`;
+
+    document.cookie = cookie;
+}
+
+function getJwtExpiration(jwt: string) {
+    const payload = jwt.split('.')[1];
+    const decodedPayload = JSON.parse(atob(payload));
+    return parseInt(decodedPayload.exp);
+}

--- a/src/lib/types/base.ts
+++ b/src/lib/types/base.ts
@@ -1,3 +1,5 @@
+export type ExtendType<T, K extends keyof T, V> = Omit<T, K> & { [P in K]?: V };
+
 export interface ResourceType {
     id: number;
     displayName: string;
@@ -11,9 +13,10 @@ export interface ResourceContentStatus {
 
 export enum ResourceContentStatusEnum {
     None = 'None',
-    AquiferizeNotStarted = 'AquiferizeNotStarted',
+    New = 'New',
     AquiferizeInProgress = 'AquiferizeInProgress',
     Complete = 'Complete',
+    AquiferizePendingReview = 'AquiferizePendingReview',
     AquiferizeInReview = 'AquiferizeInReview',
     TranslateNotStarted = 'TranslateNotStarted',
     TranslateDrafting = 'TranslateDrafting',
@@ -26,4 +29,9 @@ export interface Language {
     id: number;
     iso6393Code: string;
     englishDisplay: string;
+}
+
+export interface User {
+    id: number;
+    name: string;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,25 +10,35 @@
     import MoonIcon from '$lib/icons/MoonIcon.svelte';
     import PieChartIcon from '$lib/icons/PieChartIcon.svelte';
     import { page } from '$app/stores';
-    import { browser } from '$app/environment';
     import { onMount } from 'svelte';
     import { _ as translate } from 'svelte-i18n';
-    import { initAuth0, logout, profile, authenticated, setCurrentPageUrl } from '$lib/stores/auth';
+    import { logout, profile, auth0Client, syncAuthTokenToCookies } from '$lib/stores/auth';
     import { log } from '$lib/logger';
+    import type { LayoutData } from './$types';
 
     $: userEmail = $profile?.email ?? ' '; // set to avoid flashing undefined
     $: userFullName = $profile?.name ?? ' ';
     let theme: string | null;
-    $: browser && setCurrentPageUrl($page.url);
+
+    export let data: LayoutData;
 
     $: log.pageView($page.route.id ?? '');
 
-    onMount(async () => {
+    onMount(() => {
         if (typeof window !== 'undefined') {
             theme = window.localStorage.getItem('dataTheme') ?? 'biblioNexusLight';
         }
 
-        await initAuth0();
+        // every minute, fetch a new auth token to store as a cookie for SSR
+        const syncCookiesInterval = setInterval(() => {
+            try {
+                syncAuthTokenToCookies($auth0Client);
+            } catch (error) {
+                // ignore errors here, don't want to interrupt the user
+            }
+        }, 60 * 1000);
+
+        return () => clearInterval(syncCookiesInterval);
     });
 
     const toggleTheme = (event: Event) => {
@@ -85,7 +95,7 @@
 
 <svelte:window on:error={onError} on:unhandledrejection={onRejection} />
 
-{#if $authenticated}
+{#if data.loaded}
     <div class="drawer lg:drawer-open">
         <input id="main-drawer" type="checkbox" class="drawer-toggle" />
         <div class="drawer-content">
@@ -123,7 +133,7 @@
                             <div class="tooltip tooltip-left" data-tip={$translate('sidebar.logout.value')}>
                                 <button
                                     class="btn btn-link m-0 h-4 min-h-0 w-4 p-0 text-neutral-100"
-                                    on:click={() => logout()}
+                                    on:click={() => logout($page.url)}
                                 >
                                     <LoginIcon />
                                 </button>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,34 +1,64 @@
 import type { LayoutLoad } from './$types';
 import { waitLocale } from 'svelte-i18n';
 import { initI18n } from '$lib/i18n';
-import { fetchJsonFromApi } from '$lib/utils/http-service';
-import type { Language, ResourceContentStatus, ResourceType } from '$lib/types/base';
+import { fetchJsonFromApiWithAuth, initFetchPatch } from '$lib/utils/http-service';
+import type { Language, ResourceContentStatus, ResourceType, User } from '$lib/types/base';
+import { browser } from '$app/environment';
+import { initAuth0 } from '$lib/stores/auth';
 
-export const load: LayoutLoad = async ({ fetch }) => {
-    const [languages, resourceTypes, resourceContentStatuses] = await Promise.all([
-        getLanguages(fetch),
-        getResourceTypes(fetch),
-        getResourceContentStatuses(fetch),
-        initI18n(),
-    ]);
+export const load: LayoutLoad = async ({ fetch, url }) => {
+    let languages: Language[] | null = null;
+    let resourceTypes: ResourceType[] | null = null;
+    let resourceContentStatuses: ResourceContentStatus[] | null = null;
+    let currentUser: User | null = null;
 
+    if (browser) {
+        await initAuth0(url);
+        initFetchPatch();
+    }
+
+    [languages, resourceTypes, resourceContentStatuses, currentUser] = (
+        await Promise.allSettled([
+            getLanguages(fetch),
+            getResourceTypes(fetch),
+            getResourceContentStatuses(fetch),
+            getCurrentUser(fetch),
+        ])
+    ).map((result) => (result.status === 'fulfilled' ? result.value : null)) as [
+        Language[] | null,
+        ResourceType[] | null,
+        ResourceContentStatus[] | null,
+        User | null,
+    ];
+
+    await initI18n();
     await waitLocale();
 
+    // IMPORTANT: This type-casting is not technically correct, since the fetched data could be `null`
+    //            due to an auth error. However, we have code that conditionally renders the UI based on
+    //            the `loaded` boolean so we can be sure that when rendering any pages these are non-null.
     return {
-        languages,
-        resourceTypes,
-        resourceContentStatuses,
+        loaded:
+            languages !== null && resourceTypes !== null && resourceContentStatuses !== null && currentUser !== null,
+        languages: languages as Language[],
+        resourceTypes: resourceTypes as ResourceType[],
+        resourceContentStatuses: resourceContentStatuses as ResourceContentStatus[],
+        currentUser: currentUser as User,
     };
 };
 
 async function getLanguages(fetch: typeof window.fetch) {
-    return (await fetchJsonFromApi('/languages', {}, fetch)) as Language[];
+    return (await fetchJsonFromApiWithAuth('/languages', {}, fetch)) as Language[];
+}
+
+async function getCurrentUser(fetch: typeof window.fetch) {
+    return (await fetchJsonFromApiWithAuth('/users/self', {}, fetch)) as User;
 }
 
 async function getResourceTypes(fetch: typeof window.fetch) {
-    return (await fetchJsonFromApi('/resources/parent-resources', {}, fetch)) as ResourceType[];
+    return (await fetchJsonFromApiWithAuth('/resources/parent-resources', {}, fetch)) as ResourceType[];
 }
 
 async function getResourceContentStatuses(fetch: typeof window.fetch) {
-    return (await fetchJsonFromApi('/resources/content/statuses', {}, fetch)) as ResourceContentStatus[];
+    return (await fetchJsonFromApiWithAuth('/resources/content/statuses', {}, fetch)) as ResourceContentStatus[];
 }

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,8 +1,8 @@
 import type { PageLoad } from './$types';
-import { fetchJsonFromApi } from '$lib/utils/http-service';
+import { fetchJsonFromApiWithAuth } from '$lib/utils/http-service';
 
 export const load: PageLoad = async ({ fetch }) => {
-    const summary = (await fetchJsonFromApi('/resources/summary', {}, fetch)) as ResourcesSummary;
+    const summary = (await fetchJsonFromApiWithAuth('/resources/summary', {}, fetch)) as ResourcesSummary;
 
     return { summary };
 };

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -47,18 +47,18 @@
     function getStatusClass(status: ResourceContentStatusEnum) {
         switch (status) {
             case ResourceContentStatusEnum.TranslateNotStarted:
-            case ResourceContentStatusEnum.AquiferizeNotStarted:
-                return 'badge-neutral font-semibold';
+            case ResourceContentStatusEnum.New:
+                return 'badge-neutral';
             case ResourceContentStatusEnum.TranslateEditing:
             case ResourceContentStatusEnum.TranslateDrafting:
             case ResourceContentStatusEnum.TranslateReviewing:
             case ResourceContentStatusEnum.AquiferizeInReview:
             case ResourceContentStatusEnum.AquiferizeInProgress:
-                return 'badge-primary bg-[#B9EBFE] text-primary font-semibold';
+                return 'badge-primary bg-[#B9EBFE] text-primary';
             case ResourceContentStatusEnum.Complete:
-                return 'badge-success bg-[#ABEFC6] text-success font-semibold';
+                return 'badge-success bg-[#ABEFC6] text-success';
             default:
-                return 'badge-info font-semibold';
+                return 'badge-info';
         }
     }
 
@@ -169,7 +169,7 @@
                             </LinkedTableCell>
                             <LinkedTableCell href={`/resources/${contentId}`}>
                                 <div
-                                    class="badge
+                                    class="badge font-semibold
                                     {getStatusClass(resource.status)}"
                                 >
                                     {getStatusName(resource.status)}

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -10,8 +10,7 @@
     import { originalValues, updatedValues, resetUpdated, updateOriginal } from '$lib/stores/tiptapContent';
     import { beforeNavigate, goto } from '$app/navigation';
     import { canEdit } from '$lib/stores/auth';
-    import { fetchFromApi, unwrapStreamedData } from '$lib/utils/http-service';
-    import { auth0Client } from '$lib/stores/auth';
+    import { fetchFromApiWithAuth, unwrapStreamedData } from '$lib/utils/http-service';
     import CenteredSpinner from '$lib/components/CenteredSpinner.svelte';
 
     beforeNavigate((x) => {
@@ -66,18 +65,13 @@
 
     const putData = async () => {
         try {
-            const token = await $auth0Client?.getTokenSilently();
-            await fetchFromApi(`/resources/content/summary/${$updatedValues.contentId}`, {
+            await fetchFromApiWithAuth(`/resources/content/summary/${$updatedValues.contentId}`, {
                 method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${token}`,
-                },
-                body: JSON.stringify({
+                body: {
                     status: $updatedValues.status,
                     displayName: $updatedValues.displayName,
                     content: $updatedValues.content,
-                }),
+                },
             });
 
             updateOriginal();

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,6 +427,11 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz"
   integrity sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.0.tgz#0709e9f4cb252351c609c6e6d8d6779a8d25edff"
+  integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
+
 "@formatjs/ecma402-abstract@1.11.4":
   version "1.11.4"
   resolved "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz"
@@ -752,41 +757,42 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@sveltejs/kit@^1.20.4":
-  version "1.23.0"
-  resolved "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.23.0.tgz"
-  integrity sha512-MuDM6afpSMnPFMtEsE1O+Qn6NVPNHDqsDYYZE/8/+Z3IvGmE+GKHC+za6fEmCfwXLqNlxFZiV8s8kKOeNVJP+g==
+"@sveltejs/kit@^1.29.1":
+  version "1.29.1"
+  resolved "https://registry.yarnpkg.com/@sveltejs/kit/-/kit-1.29.1.tgz#91114790ec7b3e18f0869940323216de31192e88"
+  integrity sha512-zbHS6hy2OZLWTmkTktx7jpPaE5Qg9tk3li+wh06ISSLEYeiPrLlPMuhzmI2gM5d6ParNfDx7YCiPTeRr23IpMw==
   dependencies:
-    "@sveltejs/vite-plugin-svelte" "^2.4.1"
+    "@sveltejs/vite-plugin-svelte" "^2.5.0"
     "@types/cookie" "^0.5.1"
     cookie "^0.5.0"
     devalue "^4.3.1"
     esm-env "^1.0.0"
     kleur "^4.1.5"
     magic-string "^0.30.0"
-    mime "^3.0.0"
+    mrmime "^1.0.1"
     sade "^1.8.1"
     set-cookie-parser "^2.6.0"
     sirv "^2.0.2"
-    undici "~5.23.0"
+    tiny-glob "^0.2.9"
+    undici "~5.26.2"
 
-"@sveltejs/vite-plugin-svelte-inspector@^1.0.3":
+"@sveltejs/vite-plugin-svelte-inspector@^1.0.4":
   version "1.0.4"
-  resolved "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.4.tgz#c99fcb73aaa845a3e2c0563409aeb3ee0b863add"
   integrity sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==
   dependencies:
     debug "^4.3.4"
 
-"@sveltejs/vite-plugin-svelte@^2.4.1":
-  version "2.4.5"
-  resolved "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.4.5.tgz"
-  integrity sha512-UJKsFNwhzCVuiZd06jM/psscyNJNDwjQC+qIeb7GBJK9iWeQCcIyfcPWDvbCudfcJggY9jtxJeeaZH7uny93FQ==
+"@sveltejs/vite-plugin-svelte@^2.5.0":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.5.3.tgz#23f810d0c38d159491845175c2566a51639be3fc"
+  integrity sha512-erhNtXxE5/6xGZz/M9eXsmI7Pxa6MS7jyTy06zN3Ck++ldrppOnOlJwHHTsMC7DHDQdgUp4NAc4cDNQ9eGdB/w==
   dependencies:
-    "@sveltejs/vite-plugin-svelte-inspector" "^1.0.3"
+    "@sveltejs/vite-plugin-svelte-inspector" "^1.0.4"
     debug "^4.3.4"
     deepmerge "^4.3.1"
     kleur "^4.1.5"
-    magic-string "^0.30.2"
+    magic-string "^0.30.3"
     svelte-hmr "^0.15.3"
     vitefu "^0.2.4"
 
@@ -1628,13 +1634,6 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
-
-busboy@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz"
-  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
-  dependencies:
-    streamsearch "^1.1.0"
 
 cac@^6.7.14:
   version "6.7.14"
@@ -3984,10 +3983,17 @@ magic-string@^0.27.0:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.13"
 
-magic-string@^0.30.0, magic-string@^0.30.2:
+magic-string@^0.30.0:
   version "0.30.3"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz"
   integrity sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
+magic-string@^0.30.3:
+  version "0.30.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.5.tgz#1994d980bd1c8835dc6e78db7cbd4ae4f24746f9"
+  integrity sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
 
@@ -4082,11 +4088,6 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz"
-  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -4146,7 +4147,7 @@ mri@^1.1.0:
   resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
-mrmime@^1.0.0:
+mrmime@^1.0.0, mrmime@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz"
   integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
@@ -5316,11 +5317,6 @@ stoppable@^1.1.0:
   resolved "https://registry.yarnpkg.com/stoppable/-/stoppable-1.1.0.tgz#32da568e83ea488b08e4d7ea2c3bcc9d75015d5b"
   integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
-streamsearch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
-  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
-
 string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -5755,12 +5751,12 @@ ufo@^1.1.2:
   resolved "https://registry.npmjs.org/ufo/-/ufo-1.2.0.tgz"
   integrity sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==
 
-undici@~5.23.0:
-  version "5.23.0"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz"
-  integrity sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==
+undici@~5.26.2:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.26.5.tgz#f6dc8c565e3cad8c4475b187f51a13e505092838"
+  integrity sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==
   dependencies:
-    busboy "^1.6.0"
+    "@fastify/busboy" "^2.0.0"
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
In order to allow this authorized endpoint to be accessed by the SSR SvelteKit path, some
refactoring of auth stuff needed to happen. This sets us up well for any future admin
endpoints that require authorization.

The approach here is:
1) Initialize auth from the client and set a 5-minute access token as a cookie
2) Keep this cookie current by setting it every minute
3) When a new page is server-side rendered, there are two possible paths:
  a) The auth token cookie exists, in which case we forward it as a Bearer token to the API and the
     data can be fetched by the server.
  b) The auth token cookie does not exist (e.g. the user loads the page fresh after inactivity), in
     which case the data can't be fetched by the server, so the client ends up making the requests
     itself.

This also updates the resource content status enum to match the new server values.
