### PR TITLE
pull permissions for current user and skip authorized fetches if missing permissions

### DIFF
--- a/src/lib/types/base.ts
+++ b/src/lib/types/base.ts
@@ -35,3 +35,16 @@ export interface User {
     id: number;
     name: string;
 }
+
+export enum Permission {
+    AquiferizeContent = 'aquiferize:content',
+    PublishContent = 'publish:content',
+    AssignContent = 'assign:content',
+    AssignOverride = 'assign:override',
+    ReadValues = 'read:values',
+    WriteValues = 'write:values',
+}
+
+export interface CurrentUser extends User {
+    permissions: Permission[];
+}

--- a/src/lib/utils/http-service.ts
+++ b/src/lib/utils/http-service.ts
@@ -15,6 +15,10 @@ export type StreamedData<T> = { streamed: Promise<StreamedError | T> };
 
 type CustomFetchOptions = ExtendType<FetchOptions, 'body', object | undefined>;
 
+interface HttpError {
+    status?: number;
+}
+
 interface FetchOptions extends RequestInit {
     headers?: Record<string, string>;
 }
@@ -154,7 +158,7 @@ export async function fetchJsonFromApiWithAuth<T = never>(
         // implementation. Any user coming to the site after inactivity won't have a cookie and the SSR will not be
         // able to authenticate properly. But then the client (which will have the token) will refetch the data and
         // things will work.
-        if (!browser && (error as { status: number }).status && (error as { status: number }).status === 401) {
+        if (!browser && (error as HttpError).status === 401) {
             console.log('Missing auth token during SSR fetch. Client will re-fetch and handle any errors.', error);
             return null;
         } else {

--- a/src/routes/resources/[resourceContentId]/+page.ts
+++ b/src/routes/resources/[resourceContentId]/+page.ts
@@ -1,11 +1,9 @@
 import type { PageLoad } from './$types';
-import { fetchJsonFromApiWithAuth, fetchJsonStreamingFromApi } from '$lib/utils/http-service';
+import { fetchJsonStreamingFromApi } from '$lib/utils/http-service';
 import type { ResourceContent } from '$lib/types/resources';
-import type { User } from '$lib/types/base';
 
 export const load: PageLoad = async ({ params, fetch }) => {
     return {
-        users: await fetchJsonFromApiWithAuth<User[]>('/admin/users', {}, fetch),
         streamedResourceContent: fetchJsonStreamingFromApi<ResourceContent>(
             `/admin/resources/content/summary/${params.resourceContentId}`,
             {},


### PR DESCRIPTION
Right now when going to the resource edit page as a read-only user, the page errors out. This is because we're fetching the `/admin/users` endpoint to populate the publish/aquiferize modal dropdowns. In the case where the user is read-only, they don't have permissions to access that endpoint. There are a couple possible fixes, one of which is just to swallow the 403s in some cases. However, the best solution is to just not make the fetch if we know the user doesn't have permission.

This also has the added benefit of giving us access to the user's permissions from any page, both during SSR as well as on the client. I know this is a bit controversial @jwinston-bn in terms of if we use roles vs permissions, but with this data there we've got the option to do either if we want to.