### PR TITLE
only show send to review button if user is assigned

### DIFF
--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -19,7 +19,6 @@ export enum Permission {
     AssignContent = 'assign:content',
     AssignOverride = 'assign:override',
     SendReviewContent = 'send-review:content',
-    SendReviewOverride = 'send-review:override',
     ReviewContent = 'review:content',
     ReadUsers = 'read:users',
     EditContent = 'edit:content',

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -82,8 +82,8 @@
             resourceContent.status === ResourceContentStatusEnum.AquiferizeInReview;
 
         canSendReview =
-            (data.currentUser.can(Permission.SendReviewOverride) ||
-                (data.currentUser.can(Permission.SendReviewContent) && currentUserIsAssigned)) &&
+            data.currentUser.can(Permission.SendReviewContent) &&
+            currentUserIsAssigned &&
             resourceContent.status === ResourceContentStatusEnum.AquiferizeInProgress;
 
         canStartReview =


### PR DESCRIPTION
The initial requirements were to allow publishers to send to review at any point, but we're removing that ability. The publisher can still send to review if they want by assigning to themselves and then doing send to review.