### PR TITLE
improve error handling by logging the message from the server

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,8 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import config from '$lib/config';
 import { browser } from '$app/environment';
+import { profile } from './stores/auth';
+import { get } from 'svelte/store';
 
 const appInsights = new ApplicationInsights({
     config: {
@@ -22,11 +24,11 @@ const additionalProperties = {
 export const log = {
     exception: (error: Error | undefined) => {
         // Distinguish between network errors (which can't be avoided) and other errors we may want to look into
-        if (error && error.name === 'TypeError' && error.message === 'Failed to fetch') {
+        if (error && error.message.includes('Failed to fetch')) {
             console.error(error);
         } else if (error) {
             console.error(error);
-            appInsights.trackException({ exception: error }, additionalProperties);
+            appInsights.trackException({ exception: error }, { ...additionalProperties, userName: get(profile)?.name });
         }
     },
     pageView: (routeId: string) => {


### PR DESCRIPTION
Improves several things:
1) adds the server's error message to the app insight logs
2) adds the user's name to the app insight logs so we know who it happened to
3) filters out more "failed to fetch" errors
4) prevents duplicate `HTTP error. ... Message: 'HTTP error. ...'` from showing up like this:
<img width="1010" alt="image" src="https://github.com/BiblioNexusStudio/content-manager-web/assets/4652012/468ac27f-5851-4bac-ae2e-9de301108d8f">
