### PR TITLE
auto-save when assigning or sending to review

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -24,7 +24,7 @@ const additionalProperties = {
 export const log = {
     exception: (error: Error | undefined) => {
         // Distinguish between network errors (which can't be avoided) and other errors we may want to look into
-        if (error && error.message.includes('Failed to fetch')) {
+        if (error && (error.message.includes('Failed to fetch') || error.message.includes('Load failed'))) {
             console.error(error);
         } else if (error) {
             console.error(error);

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -122,6 +122,9 @@
 
     async function takeActionAndRefresh(action: () => Promise<unknown>) {
         isTransacting = true;
+        if (contentUpdated) {
+            await putData();
+        }
         try {
             await action();
             window.location.reload(); // do this for now. eventually we want to have the post return the new state of the resource so we don't need to refresh


### PR DESCRIPTION
When a user is assigned content and has made changes, then they attempt to assign or send to review,
we should auto-save the changes they've made.

Also updates error handling to ignore "Load failed" errors ,which is the iOS network failure error.
