### PR TITLE
ensure error message exists before running includes

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -24,7 +24,11 @@ const additionalProperties = {
 export const log = {
     exception: (error: Error | undefined) => {
         // Distinguish between network errors (which can't be avoided) and other errors we may want to look into
-        if (error && (error.message.includes('Failed to fetch') || error.message.includes('Load failed'))) {
+        if (
+            error &&
+            error.message &&
+            (error.message.includes('Failed to fetch') || error.message.includes('Load failed'))
+        ) {
             console.error(error);
         } else if (error) {
             console.error(error);

--- a/src/lib/utils/http-service.ts
+++ b/src/lib/utils/http-service.ts
@@ -82,7 +82,7 @@ export function fetchJsonStreamingFromApi<T = never>(
                     resolve({
                         _isError: true,
                         code: maybeCode,
-                        message: error.message.includes('HTTP error.')
+                        message: error.message?.includes('HTTP error.')
                             ? error.message
                             : errorMessage(error.message, maybeCode, pathPrefixedWithSlash(path)),
                     } as StreamedError);


### PR DESCRIPTION
It looked like we were getting some error logs that could've been from running `includes` against undefined error messages.