### PR TITLE
improve token refresh code to kick user to login once their session ends

### DIFF
--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -77,15 +77,19 @@ export async function initAuth0(url: URL) {
 export async function syncAuthTokenToCookies(client: Auth0Client | undefined, url: URL, logoutOnError: boolean) {
     if (client) {
         try {
-            const authToken = await client.getTokenSilently();
+            if (await client.isAuthenticated()) {
+                const authToken = await client.getTokenSilently();
 
-            // set an AuthToken cookie so that SSR requests receive a cookie that can be used against the API
-            setCookie(AUTH_COOKIE_NAME, authToken, {
-                path: '/',
-                sameSite: 'strict',
-                expires: getJwtExpiration(authToken),
-                secure: !dev,
-            });
+                // set an AuthToken cookie so that SSR requests receive a cookie that can be used against the API
+                setCookie(AUTH_COOKIE_NAME, authToken, {
+                    path: '/',
+                    sameSite: 'strict',
+                    expires: getJwtExpiration(authToken),
+                    secure: !dev,
+                });
+            } else {
+                await logout(url);
+            }
         } catch {
             if (logoutOnError) {
                 await logout(url);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,9 +32,7 @@
         }
 
         // every minute, fetch a new auth token to store as a cookie for SSR
-        const syncCookiesInterval = setInterval(() => {
-            syncAuthTokenToCookies(auth0Client, $page.url, false);
-        }, 60 * 1000);
+        const syncCookiesInterval = setInterval(syncCookies, 60 * 1000);
 
         return () => clearInterval(syncCookiesInterval);
     });
@@ -84,6 +82,10 @@
         const error = event.reason as Error;
         event.preventDefault();
         log.exception(error);
+    }
+
+    function syncCookies() {
+        syncAuthTokenToCookies(auth0Client, $page.url, false);
     }
 </script>
 


### PR DESCRIPTION
Instead of silently failing for unauthenticated users, kick them back to the login screen when the token refresh handler detects they're no longer signed in.