### PR TITLE
only show send back button for assigned users

### DIFF
--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -77,8 +77,8 @@
             resourceContent.status === ResourceContentStatusEnum.AquiferizeInProgress;
 
         canSendBack =
-            (data.currentUser.can(Permission.AssignOverride) ||
-                (data.currentUser.can(Permission.AssignContent) && currentUserIsAssigned)) &&
+            data.currentUser.can(Permission.AssignContent) &&
+            currentUserIsAssigned &&
             resourceContent.status === ResourceContentStatusEnum.AquiferizeInReview;
 
         canSendReview =


### PR DESCRIPTION
Per our initial requirements, we should only be showing the Send Back button for publishers who are
currently assigned the content. Right now it shows for anyone with assign or assign override
permissions.
