### PR TITLE
fix workflow for non-text resource types (images)

### DIFF
--- a/src/lib/components/resources/Content.svelte
+++ b/src/lib/components/resources/Content.svelte
@@ -4,10 +4,9 @@
     import TiptapContent from './content-components/TiptapContent.svelte';
     import { MediaTypeEnum, type ResourceContentVersion } from '$lib/types/resources';
 
-    export let mediaType: string;
+    export let mediaType: MediaTypeEnum;
     export let resourceContentVersion: ResourceContentVersion;
     export let canEdit: boolean;
-    export let contentId: number;
 </script>
 
 <div class="relative flex h-full grow flex-col rounded-lg border border-base-300 bg-base-200">
@@ -18,7 +17,7 @@
         {:else if mediaType === MediaTypeEnum.video}
             <Video content={resourceContentVersion.content} />
         {:else if mediaType === MediaTypeEnum.text}
-            <TiptapContent {canEdit} {resourceContentVersion} {contentId} />
+            <TiptapContent {canEdit} {resourceContentVersion} />
         {/if}
     </div>
 </div>

--- a/src/lib/components/resources/content-components/TiptapContent.svelte
+++ b/src/lib/components/resources/content-components/TiptapContent.svelte
@@ -8,11 +8,10 @@
 
     export let resourceContentVersion: ResourceContentVersion;
     export let canEdit: boolean;
-    export let contentId: number;
 
     $: content = resourceContentVersion.content as unknown as TiptapContentItemValues[];
     $: currentResourceStepsLength = content.length || 0;
-    $: setOriginalValues({ contentId, content });
+    $: setOriginalValues({ content });
     $: stepNavigation = currentResourceStepsLength > 1;
 
     const headings = [

--- a/src/lib/components/tiptap/Tiptap.svelte
+++ b/src/lib/components/tiptap/Tiptap.svelte
@@ -66,7 +66,9 @@
     function levelSetOriginalAndUpdatedState(editor: Editor, index: number) {
         $originalValues.content![index].tiptap = editor.getJSON();
         $updatedValues.content![index].tiptap = editor.getJSON();
-        $originalValues.wordCounts![index] = editor.storage.characterCount.words();
+        $originalValues.wordCounts ||= [];
+        $originalValues.wordCounts[index] = editor.storage.characterCount.words();
+        $updatedValues.wordCounts ||= [];
         $updatedValues.wordCounts![index] = editor.storage.characterCount.words();
     }
 
@@ -119,7 +121,8 @@
                     },
                     onUpdate: ({ editor }) => {
                         $updatedValues.content![index].tiptap = editor.getJSON();
-                        $updatedValues.wordCounts![index] = editor.storage.characterCount.words();
+                        $updatedValues.wordCounts ||= [];
+                        $updatedValues.wordCounts[index] = editor.storage.characterCount.words();
                     },
                     onCreate: ({ editor }) => {
                         // Need to call this here because the formatting of editor.getJSON has the possibility of being different

--- a/src/lib/stores/tiptapContent.ts
+++ b/src/lib/stores/tiptapContent.ts
@@ -2,16 +2,14 @@
 import type { JSONContent } from '@tiptap/core';
 
 export const originalValues: Writable<TiptapContentValues> = writable({
-    contentId: undefined,
     content: undefined,
-    wordCounts: [],
+    wordCounts: null,
     displayName: undefined,
 });
 
 export const updatedValues: Writable<TiptapContentValues> = writable({
-    contentId: undefined,
     content: undefined,
-    wordCounts: [],
+    wordCounts: null,
     displayName: undefined,
 });
 
@@ -35,10 +33,9 @@ export const updateOriginal = () => {
 export const userStoppedEditing = writable(false);
 
 export interface TiptapContentValues {
-    contentId?: number | undefined;
     content?: TiptapContentItemValues[] | undefined;
     displayName?: string | undefined;
-    wordCounts?: number[];
+    wordCounts?: number[] | null;
 }
 
 export interface TiptapContentItemValues {

--- a/src/lib/types/resources.ts
+++ b/src/lib/types/resources.ts
@@ -76,7 +76,7 @@ export interface ContentItem {
 }
 
 export interface AssociatedResource {
-    mediaTypes: string[];
+    mediaTypes: MediaTypeEnum[];
     parentResourceName: string;
     label: string;
 }
@@ -100,7 +100,7 @@ export interface ResourceContent {
     associatedResources: AssociatedResource[];
     parentResourceName: string;
     resourceContentId: number;
-    mediaType: string;
+    mediaType: MediaTypeEnum;
     status: ResourceContentStatusEnum;
     language: Language;
     hasAudio: boolean;

--- a/src/routes/resources/[resourceContentId]/+page.ts
+++ b/src/routes/resources/[resourceContentId]/+page.ts
@@ -4,6 +4,7 @@ import type { ResourceContent } from '$lib/types/resources';
 
 export const load: PageLoad = async ({ params, fetch }) => {
     return {
+        resourceContentId: params.resourceContentId,
         streamedResourceContent: fetchJsonStreamingFromApi<ResourceContent>(
             `/admin/resources/content/summary/${params.resourceContentId}`,
             {},


### PR DESCRIPTION
Non-text resources could not be updated correctly by clicking workflow buttons like "Unpublish" "Aquiferize", etc. This fixes that issue and make the word count handling work slightly better.