### PR TITLE
fix heights of resource page panes so they fit content and fix null user message

### DIFF
--- a/src/lib/components/resources/BibleReferences.svelte
+++ b/src/lib/components/resources/BibleReferences.svelte
@@ -25,7 +25,7 @@
     }
 </script>
 
-<div class="flex max-h-72 grow flex-col rounded-lg border border-base-300 bg-base-200">
+<div class="flex h-fit max-h-72 flex-col rounded-lg border border-base-300 bg-base-200">
     <div class="px-4 py-2 text-xl font-medium">Bible References</div>
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex w-full flex-col">

--- a/src/lib/components/resources/Overview.svelte
+++ b/src/lib/components/resources/Overview.svelte
@@ -28,7 +28,7 @@
     }
 </script>
 
-<div class="mb-4 flex grow flex-col rounded-lg border border-base-300 bg-base-200">
+<div class="mb-4 flex h-fit flex-col rounded-lg border border-base-300 bg-base-200">
     <div class="px-4 py-2 text-xl font-medium">Overview</div>
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex flex-col">

--- a/src/lib/components/resources/Process.svelte
+++ b/src/lib/components/resources/Process.svelte
@@ -8,7 +8,7 @@
     export let resourceContentStatuses: ResourceContentStatus[];
 </script>
 
-<div class="mb-4 flex grow flex-col rounded-lg border border-base-300 bg-base-200">
+<div class="mb-4 flex h-fit flex-col rounded-lg border border-base-300 bg-base-200">
     <div class="px-4 py-2 text-xl font-medium">Process</div>
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex w-full justify-between">

--- a/src/lib/components/resources/RelatedContent.svelte
+++ b/src/lib/components/resources/RelatedContent.svelte
@@ -22,7 +22,7 @@
     }
 </script>
 
-<div class="mb-4 flex max-h-72 grow flex-col rounded-lg border border-base-300 bg-base-200">
+<div class="mb-4 flex h-fit max-h-72 flex-col rounded-lg border border-base-300 bg-base-200">
     <div class="px-4 py-2 text-xl font-medium">Related Content</div>
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex flex-col">

--- a/src/lib/components/resources/Translations.svelte
+++ b/src/lib/components/resources/Translations.svelte
@@ -17,7 +17,7 @@
         .sort((a, b) => a.languageName.localeCompare(b.languageName));
 </script>
 
-<div class="mb-4 flex grow flex-col rounded-lg border border-base-300 bg-base-200">
+<div class="mb-4 flex h-fit flex-col rounded-lg border border-base-300 bg-base-200">
     <div class="px-4 py-2 text-xl font-medium">Translations</div>
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex flex-col">

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -6,6 +6,10 @@ import { redirect } from '@sveltejs/kit';
 export const load: PageLoad = async ({ fetch, parent }) => {
     const data = await parent();
 
+    if (!data.currentUser) {
+        return {};
+    }
+
     if (data.currentUser.is(Role.Publisher)) {
         const reportingSummary = fetchJsonStreamingFromApi(
             '/admin/resources/summary',


### PR DESCRIPTION
The resource page has panes on the left that were set to grow in height and expand to take up the
full space. By using fit-content we can make them smaller when they should be.

Also there was a slight regression introduced recently where after the user has been away for long
enough to expire the access token, when they refresh the dashboard they would see an error message.
This fixes it.
