### PR TITLE
Fix non publisher seeing add translation button

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -120,7 +120,7 @@
                         <div class="flex-grow-0">
                             <a
                                 href={navItem.href}
-                                class="btn btn-neutral btn-ghost btn-block justify-start px-2 text-lg normal-case text-neutral-100"
+                                class="btn btn-ghost btn-neutral btn-block justify-start px-2 text-lg normal-case text-neutral-100"
                                 ><svelte:component this={navItem.icon} />{navItem.name}</a
                             >
                         </div>

--- a/src/routes/PublisherDashboard.svelte
+++ b/src/routes/PublisherDashboard.svelte
@@ -53,7 +53,7 @@
 {:then [assignedContents, pendingReviewContents, reportingSummary]}
     <div class="flex max-h-screen flex-col overflow-y-hidden px-4">
         <h1 class="pt-4 text-3xl">Publisher Dashboard</h1>
-        <div role="tablist" class="tabs-bordered tabs w-fit pt-4">
+        <div role="tablist" class="tabs tabs-bordered w-fit pt-4">
             <button
                 on:click={() => ($searchParams.tab = Tab.myWork)}
                 role="tab"

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -435,7 +435,7 @@
                                 {/if}
                             </button>
                         {/if}
-                        <button class="btn btn-primary btn-outline mb-4 ms-4" on:click={onSaveAndClose}>Close</button>
+                        <button class="btn btn-outline btn-primary mb-4 ms-4" on:click={onSaveAndClose}>Close</button>
                     </div>
                 </div>
             </div>
@@ -494,7 +494,7 @@
                         on:click={isInTranslationWorkflow ? translate : aquiferize}
                         disabled={assignToUserId === null}>Assign</button
                     >
-                    <button class="btn btn-primary btn-outline" on:click={() => aquiferizeModal.close()}>Cancel</button>
+                    <button class="btn btn-outline btn-primary" on:click={() => aquiferizeModal.close()}>Cancel</button>
                 </div>
             </div>
         </div>
@@ -523,7 +523,7 @@
                         on:click={assignUser}
                         disabled={assignToUserId === null || isTransacting}>Assign</button
                     >
-                    <button class="btn btn-primary btn-outline" on:click={() => assignUserModal.close()}>Cancel</button>
+                    <button class="btn btn-outline btn-primary" on:click={() => assignUserModal.close()}>Cancel</button>
                 </div>
             </div>
         </div>
@@ -554,7 +554,7 @@
                 <div class="flex w-full flex-row space-x-2 pt-4">
                     <div class="flex-grow" />
                     <button class="btn btn-primary" on:click={publish} disabled={isTransacting}>Publish</button>
-                    <button class="btn btn-primary btn-outline" on:click={() => publishModal.close()}>Cancel</button>
+                    <button class="btn btn-outline btn-primary" on:click={() => publishModal.close()}>Cancel</button>
                 </div>
             </div>
         </div>
@@ -588,7 +588,7 @@
                         on:click={createTranslation}
                         disabled={newTranslationLanguageId === null || isTransacting}>Create</button
                     >
-                    <button class="btn btn-primary btn-outline" on:click={() => addTranslationModal.close()}
+                    <button class="btn btn-outline btn-primary" on:click={() => addTranslationModal.close()}
                         >Cancel</button
                     >
                 </div>
@@ -605,7 +605,7 @@
                     <button class="btn btn-primary" on:click={sendReview} disabled={isTransacting}
                         >Send to Review</button
                     >
-                    <button class="btn btn-primary btn-outline">Cancel</button>
+                    <button class="btn btn-outline btn-primary">Cancel</button>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
- Fix for a non publisher seeing the create translation button
- Linter thing seems to have moved some class names around
- Also addressed the impossible situation of having no languages to add, so don't show create translation button there either.