### PR TITLE
addingDirAutoToRootHtmlElement

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="h-screen" data-theme="">
+<html lang="en" class="h-screen" data-theme="" dir="auto">
     <head>
         <meta charset="utf-8" />
         <link rel="icon" href="%sveltekit.assets%/favicon.png" />


### PR DESCRIPTION
This solution was deemed the best path forward after trying to get https://github.com/amirhhashemi/tiptap-text-direction to work. The tiptap text direction plugin has weird behavior once the selected nodes are changed to right to left. The typing was not working as expected. But once auto was applied, if the user is typing in a right to left language, the browser and tiptap pick it up and work as expected. 