### PR TITLE
separate draft and published resource into different editors

### DIFF
--- a/src/lib/components/resources/Content.svelte
+++ b/src/lib/components/resources/Content.svelte
@@ -4,12 +4,14 @@
     import TiptapContent from './content-components/TiptapContent.svelte';
     import { MediaTypeEnum, type ResourceContentVersion } from '$lib/types/resources';
 
+    export let contentVersionId: string;
+    export let visible: boolean;
     export let mediaType: MediaTypeEnum;
     export let resourceContentVersion: ResourceContentVersion;
     export let canEdit: boolean;
 </script>
 
-<div class="relative flex h-full grow flex-col rounded-lg border border-base-300 bg-base-200">
+<div class="relative flex h-full grow flex-col rounded-lg border border-base-300 bg-base-200 {!visible && 'hidden'}">
     <div class="px-4 py-2 text-xl font-medium">Content</div>
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         {#if mediaType === MediaTypeEnum.image}
@@ -17,7 +19,7 @@
         {:else if mediaType === MediaTypeEnum.video}
             <Video content={resourceContentVersion.content} />
         {:else if mediaType === MediaTypeEnum.text}
-            <TiptapContent {canEdit} {resourceContentVersion} />
+            <TiptapContent {contentVersionId} {canEdit} {resourceContentVersion} />
         {/if}
     </div>
 </div>

--- a/src/lib/components/resources/Overview.svelte
+++ b/src/lib/components/resources/Overview.svelte
@@ -2,13 +2,13 @@
     import { Icon } from 'svelte-awesome';
     import PencilSquareIcon from '$lib/icons/PencilSquareIcon.svelte';
     import XSquareIcon from '$lib/icons/XSquareIcon.svelte';
-    import { originalValues, updatedValues, updateValues, setOriginalValues } from '$lib/stores/tiptapContent';
+    import { originalValues, updatedValues, updateValues } from '$lib/stores/tiptapContent';
     import checkCircleO from 'svelte-awesome/icons/checkCircleO';
     import ban from 'svelte-awesome/icons/ban';
     import { createEventDispatcher } from 'svelte';
     import type { Language } from '$lib/types/base';
 
-    export let displayNameText: string;
+    export let contentVersionId: string;
     export let typeText: string;
     export let wordCount: number | null;
     export let language: Language;
@@ -17,9 +17,14 @@
     const dispatch = createEventDispatcher();
 
     let displayNameInput: HTMLInputElement;
-    setOriginalValues({ displayName: displayNameText });
-    $: updateValues({ displayName: displayNameText });
-    $: displayNameUpdated = $originalValues?.displayName !== $updatedValues?.displayName;
+    $: displayNameText = $originalValues[contentVersionId]?.displayName;
+    $: displayNameUpdated =
+        $originalValues[contentVersionId]?.displayName !== $updatedValues[contentVersionId]?.displayName;
+
+    function updateDisplayName(event: Event) {
+        const target = event.currentTarget as HTMLInputElement;
+        updateValues(contentVersionId, { displayName: target.value });
+    }
 
     function saveOnBlur() {
         if (displayNameUpdated) {
@@ -40,7 +45,8 @@
                             <input
                                 type="text"
                                 bind:this={displayNameInput}
-                                bind:value={displayNameText}
+                                value={displayNameText}
+                                on:change={updateDisplayName}
                                 class="input input-ghost h-6 w-full pl-0 text-right"
                                 on:blur={() => saveOnBlur()}
                             />
@@ -53,7 +59,8 @@
                     <button
                         class="h-6 w-6 p-0"
                         on:click={() => {
-                            if (displayNameUpdated) displayNameText = $originalValues?.displayName || '';
+                            if (displayNameUpdated)
+                                displayNameText = $originalValues[contentVersionId]?.displayName || '';
                             else displayNameInput.focus();
                         }}
                         ><label class="swap swap-rotate">

--- a/src/lib/components/resources/content-components/TiptapContent.svelte
+++ b/src/lib/components/resources/content-components/TiptapContent.svelte
@@ -3,15 +3,15 @@
     import arrowCircleLeft from 'svelte-awesome/icons/arrowCircleLeft';
     import arrowCircleRight from 'svelte-awesome/icons/arrowCircleRight';
     import Tiptap from '$lib/components/tiptap/Tiptap.svelte';
-    import { setOriginalValues, currentStepNumber, type TiptapContentItemValues } from '$lib/stores/tiptapContent';
+    import { currentStepNumber, type TiptapContentItemValues } from '$lib/stores/tiptapContent';
     import type { ResourceContentVersion } from '$lib/types/resources';
 
+    export let contentVersionId: string;
     export let resourceContentVersion: ResourceContentVersion;
     export let canEdit: boolean;
 
     $: content = resourceContentVersion.content as unknown as TiptapContentItemValues[];
     $: currentResourceStepsLength = content.length || 0;
-    $: setOriginalValues({ content });
     $: stepNavigation = currentResourceStepsLength > 1;
 
     const headings = [
@@ -78,5 +78,5 @@
             </div>
         </div>
     {/if}
-    <Tiptap {canEdit} hasSteps={stepNavigation} />
+    <Tiptap {contentVersionId} {canEdit} hasSteps={stepNavigation} />
 </div>

--- a/src/lib/components/tiptap/Tiptap.svelte
+++ b/src/lib/components/tiptap/Tiptap.svelte
@@ -22,26 +22,26 @@
     import UndoIcon from '$lib/icons/UndoIcon.svelte';
     import RedoIcon from '$lib/icons/RedoIcon.svelte';
     import {
-        updatedValues,
         currentStepNumber,
         originalValues,
         userStoppedEditing,
-        type TiptapContentValues,
+        setOriginalTiptapAndWordCountsByIndex,
+        setUpdatedTiptapAndWordCountsByIndex,
     } from '$lib/stores/tiptapContent';
     import * as customMarks from '$lib/components/tiptap/customMarks';
     import type { ComponentType } from 'svelte';
     import TextDirection from 'tiptap-text-direction';
 
+    export let contentVersionId: string;
     export let hasSteps = false;
     export let canEdit: boolean;
 
     let parentElement: HTMLDivElement | undefined;
     let editorElements: HTMLDivElement[] | undefined;
     let editors: Editor[] = [];
-    let timeout: number | undefined;
+    let userStoppedEditingDebounceTimeout: number | undefined;
     $: currentEditor = editors[$currentStepNumber - 1];
     $: updateParentWithEditor($currentStepNumber);
-    $: updateEditorsWhenOriginalValuesChange($originalValues);
     $: currentEditor?.setEditable(canEdit);
 
     function updateParentWithEditor(stepNumber: number | undefined) {
@@ -58,102 +58,97 @@
         }
     }
 
-    function updateEditorsWhenOriginalValuesChange(originalValues: TiptapContentValues) {
-        editors.forEach((editor, index) => {
-            const selection = editor.state.selection;
-            if (originalValues.content![index]?.tiptap) {
-                editor.commands.setContent(originalValues.content![index]!.tiptap!);
-            }
-            levelSetOriginalAndUpdatedState(editor, index);
-            editor.commands.setTextSelection(selection);
-            editor.commands.focus();
-        });
-    }
-
     function levelSetOriginalAndUpdatedState(editor: Editor, index: number) {
-        if ($originalValues.content![index]) {
-            $originalValues.content![index]!.tiptap = editor.getJSON();
-        }
-        if ($updatedValues.content![index]) {
-            $updatedValues.content![index]!.tiptap = editor.getJSON();
-        }
-        $originalValues.wordCounts ||= [];
-        $originalValues.wordCounts[index] = editor.storage.characterCount.words();
-        $updatedValues.wordCounts ||= [];
-        $updatedValues.wordCounts![index] = editor.storage.characterCount.words();
+        setUpdatedTiptapAndWordCountsByIndex(
+            contentVersionId,
+            index,
+            editor.getJSON(),
+            editor.storage.characterCount.words()
+        );
+        setOriginalTiptapAndWordCountsByIndex(
+            contentVersionId,
+            index,
+            editor.getJSON(),
+            editor.storage.characterCount.words()
+        );
     }
 
     function startDebounce() {
-        if ($userStoppedEditing) {
-            $userStoppedEditing = false;
+        if ($userStoppedEditing[contentVersionId]) {
+            $userStoppedEditing[contentVersionId] = false;
         }
 
-        if (timeout) {
-            clearTimeout(timeout);
+        if (userStoppedEditingDebounceTimeout) {
+            clearTimeout(userStoppedEditingDebounceTimeout);
         }
 
-        timeout = window.setTimeout(() => {
-            $userStoppedEditing = true;
-            clearTimeout(timeout);
+        userStoppedEditingDebounceTimeout = window.setTimeout(() => {
+            $userStoppedEditing[contentVersionId] = true;
+            clearTimeout(userStoppedEditingDebounceTimeout);
         }, 3000);
     }
 
     onMount(async () => {
-        editorElements = $originalValues.content!.map((_) => document.createElement('div'));
-        editors = $originalValues.content!.map(
-            (content, index) =>
-                new Editor({
-                    element: editorElements?.[index],
-                    editable: canEdit,
-                    extensions: [
-                        StarterKit,
-                        Image,
-                        Link.configure({
-                            openOnClick: false,
-                        }),
-                        Underline,
-                        Highlight,
-                        Subscript,
-                        Superscript,
-                        TextStyle,
-                        CharacterCount.configure({}),
-                        customMarks.bibleReferenceMark,
-                        customMarks.resourceReferenceMark,
-                        TextDirection.configure({
-                            types: ['heading', 'paragraph', 'orderedList', 'bulletList', 'listItem'],
-                        }),
-                    ],
-                    editorProps: {
-                        attributes: {
-                            class: 'prose dark:prose-invert prose-sm sm:prose-base focus:outline-none text-black mx-4 max-w-none',
+        const tiptapValues = $originalValues[contentVersionId];
+        if (tiptapValues) {
+            editorElements = tiptapValues.content!.map((_) => document.createElement('div'));
+            editors = tiptapValues.content!.map(
+                (content, index) =>
+                    new Editor({
+                        element: editorElements?.[index],
+                        editable: canEdit,
+                        extensions: [
+                            StarterKit,
+                            Image,
+                            Link.configure({
+                                openOnClick: false,
+                            }),
+                            Underline,
+                            Highlight,
+                            Subscript,
+                            Superscript,
+                            TextStyle,
+                            CharacterCount.configure({}),
+                            customMarks.bibleReferenceMark,
+                            customMarks.resourceReferenceMark,
+                            TextDirection.configure({
+                                types: ['heading', 'paragraph', 'orderedList', 'bulletList', 'listItem'],
+                            }),
+                        ],
+                        editorProps: {
+                            attributes: {
+                                class: 'prose dark:prose-invert prose-sm sm:prose-base focus:outline-none text-black mx-4 max-w-none',
+                            },
                         },
-                    },
-                    content: content.tiptap,
-                    onTransaction: () => {
-                        // force re-render so `editor.isActive` works as expected
-                        currentEditor = currentEditor;
-                    },
-                    onUpdate: ({ editor }) => {
-                        if ($updatedValues.content![index]) {
-                            $updatedValues.content![index]!.tiptap = editor.getJSON();
-                        }
-                        $updatedValues.wordCounts ||= [];
-                        $updatedValues.wordCounts[index] = editor.storage.characterCount.words();
-                    },
-                    onCreate: ({ editor }) => {
-                        // Need to call this here because the formatting of editor.getJSON has the possibility of being different
-                        // from what's in the database.
-                        levelSetOriginalAndUpdatedState(editor, index);
-                    },
-                })
-        );
-        updateParentWithEditor($currentStepNumber);
+                        content: content.tiptap,
+                        onTransaction: () => {
+                            // force re-render so `editor.isActive` works as expected
+                            currentEditor = currentEditor;
+                        },
+                        onUpdate: ({ editor }) => {
+                            setUpdatedTiptapAndWordCountsByIndex(
+                                contentVersionId,
+                                index,
+                                editor.getJSON(),
+                                editor.storage.characterCount.words()
+                            );
+                        },
+                        onCreate: ({ editor }) => {
+                            // Need to call this here because the formatting of editor.getJSON has the possibility of being different
+                            // from what's in the database.
+                            levelSetOriginalAndUpdatedState(editor, index);
+                        },
+                    })
+            );
+            updateParentWithEditor($currentStepNumber);
+        }
     });
 
     onDestroy(() => {
         if (editors) {
             editors.forEach((e) => e.destroy());
         }
+        clearTimeout(userStoppedEditingDebounceTimeout);
     });
 
     // Intentionally adding comments blocks here.
@@ -173,43 +168,68 @@
         { level: 3, icon: Heading3Icon },
     ];
 
-    const formattingOptions = [
-        {
-            name: 'undo',
-            onClick: () => currentEditor?.commands.undo(),
-            icon: UndoIcon,
-        },
-        {
-            name: 'redo',
-            onClick: () => currentEditor?.commands.redo(),
-            icon: RedoIcon,
-        },
-        {
-            name: 'bold',
-            onClick: () => currentEditor?.chain().focus().toggleBold().run(),
-            icon: BoldIcon,
-        },
-        {
-            name: 'italic',
-            onClick: () => currentEditor?.chain().focus().toggleItalic().run(),
-            icon: ItalicsIcon,
-        },
-        {
-            name: 'underline',
-            onClick: () => currentEditor?.chain().focus().toggleUnderline().run(),
-            icon: UnderlineIcon,
-        },
-        {
-            name: 'bulletList',
-            onClick: () => currentEditor?.chain().focus().toggleBulletList().run(),
-            icon: UnorderedListIcon,
-        },
-        {
-            name: 'orderedList',
-            onClick: () => currentEditor?.chain().focus().toggleOrderedList().run(),
-            icon: OrderedListIcon,
-        },
-    ];
+    function formattingOptions(currentEditor: Editor) {
+        return [
+            {
+                name: 'undo',
+                onClick: () => {
+                    currentEditor.commands.undo();
+                    startDebounce();
+                },
+                disabled: !currentEditor.can().undo(),
+                icon: UndoIcon,
+            },
+            {
+                name: 'redo',
+                onClick: () => {
+                    currentEditor.commands.redo();
+                    startDebounce();
+                },
+                disabled: !currentEditor.can().redo(),
+                icon: RedoIcon,
+            },
+            {
+                name: 'bold',
+                onClick: () => {
+                    currentEditor.chain().focus().toggleBold().run();
+                    startDebounce();
+                },
+                icon: BoldIcon,
+            },
+            {
+                name: 'italic',
+                onClick: () => {
+                    currentEditor.chain().focus().toggleItalic().run();
+                    startDebounce();
+                },
+                icon: ItalicsIcon,
+            },
+            {
+                name: 'underline',
+                onClick: () => {
+                    currentEditor.chain().focus().toggleUnderline().run();
+                    startDebounce();
+                },
+                icon: UnderlineIcon,
+            },
+            {
+                name: 'bulletList',
+                onClick: () => {
+                    currentEditor.chain().focus().toggleBulletList().run();
+                    startDebounce();
+                },
+                icon: UnorderedListIcon,
+            },
+            {
+                name: 'orderedList',
+                onClick: () => {
+                    currentEditor.chain().focus().toggleOrderedList().run();
+                    startDebounce();
+                },
+                icon: OrderedListIcon,
+            },
+        ];
+    }
 
     const getContentTopPadding = () => {
         if (canEdit && hasSteps) {
@@ -231,11 +251,11 @@
             : 'top-[44px]'} z-20 flex h-16 w-[calc(100%-10px)] items-center rounded-md bg-white"
     >
         <div class="mx-6 mt-2">
-            {#each formattingOptions as option}
+            {#each formattingOptions(currentEditor) as option}
                 <button
-                    class="btn btn-xs mx-1 px-0 hover:bg-[#e6f7fc] {currentEditor.isActive(option.name)
-                        ? 'btn-primary'
-                        : 'btn-link'}"
+                    class="btn btn-xs mx-1 px-0 hover:bg-[#e6f7fc] {option.disabled &&
+                        '!bg-white'} {currentEditor.isActive(option.name) ? 'btn-primary' : 'btn-link'}"
+                    disabled={option.disabled}
                     on:click={option.onClick}
                 >
                     <svelte:component this={option.icon} />
@@ -248,7 +268,10 @@
                     })
                         ? 'btn-primary'
                         : 'btn-link'}"
-                    on:click={() => currentEditor?.chain().focus().toggleHeading({ level: header.level }).run()}
+                    on:click={() => {
+                        currentEditor?.chain().focus().toggleHeading({ level: header.level }).run();
+                        startDebounce();
+                    }}
                 >
                     <svelte:component this={header.icon} />
                 </button>

--- a/src/lib/stores/tiptapContent.ts
+++ b/src/lib/stores/tiptapContent.ts
@@ -1,36 +1,109 @@
 ﻿import { type Writable, writable, get } from 'svelte/store';
 import type { JSONContent } from '@tiptap/core';
+import type { ResourceContent } from '$lib/types/resources';
 
-export const originalValues: Writable<TiptapContentValues> = writable({
-    content: undefined,
-    wordCounts: null,
-    displayName: undefined,
-});
+export const originalValues: Writable<Record<string, TiptapContentValues>> = writable({});
 
-export const updatedValues: Writable<TiptapContentValues> = writable({
-    content: undefined,
-    wordCounts: null,
-    displayName: undefined,
-});
+export const updatedValues: Writable<Record<string, TiptapContentValues>> = writable({});
 
 export const currentStepNumber: Writable<number> = writable(1, (set) => set(1));
 
-export const updateValues = (values: TiptapContentValues) => {
-    updatedValues.update((x) => ({ ...x, ...values }));
+// This is to give a unique id to each content version for now, until we can update the API
+// to send the real content version down
+export function fakeContentVersionId(resourceContent: ResourceContent, versionIndex: number) {
+    return `${resourceContent.resourceContentId}.${versionIndex}`;
+}
+
+export const updateValues = (contentVersionId: string, values: TiptapContentValues) => {
+    updatedValues.update((existing) => ({
+        ...existing,
+        [contentVersionId]: { ...existing[contentVersionId], ...values },
+    }));
 };
 
-export const setOriginalValues = (values: TiptapContentValues) => {
-    originalValues.update((x) => ({ ...x, ...values }));
-    const json = JSON.stringify(values);
-    const clone = JSON.parse(json);
-    updateValues(clone);
+export const setOriginalValues = (resourceContent: ResourceContent) => {
+    originalValues.set(
+        Object.fromEntries(
+            resourceContent.contentVersions.map((version, index) => {
+                return [
+                    fakeContentVersionId(resourceContent, index),
+                    {
+                        displayName: version.displayName,
+                        content: version.content as unknown as TiptapContentItemValues[],
+                    },
+                ];
+            })
+        )
+    );
+    updatedValues.set(
+        Object.fromEntries(
+            resourceContent.contentVersions.map((version, index) => {
+                return [
+                    fakeContentVersionId(resourceContent, index),
+                    {
+                        displayName: version.displayName,
+                        content: version.content as unknown as TiptapContentItemValues[],
+                    },
+                ];
+            })
+        )
+    );
 };
 
-export const updateOriginal = () => {
-    originalValues.set(JSON.parse(JSON.stringify(get(updatedValues))));
+export const setUpdatedTiptapAndWordCountsByIndex = (
+    contentVersionId: string,
+    index: number,
+    newTiptapJson: JSONContent,
+    newWordCount: number
+) => {
+    updatedValues.update((existing) => {
+        let wordCounts = existing[contentVersionId]?.wordCounts;
+        wordCounts ||= [];
+        wordCounts[index] = newWordCount;
+        return {
+            ...existing,
+            [contentVersionId]: {
+                ...existing[contentVersionId],
+                content: existing[contentVersionId]?.content?.map((item, idx) =>
+                    idx === index ? { ...item, tiptap: newTiptapJson } : item
+                ),
+                wordCounts,
+            },
+        };
+    });
 };
 
-export const userStoppedEditing = writable(false);
+export const setOriginalTiptapAndWordCountsByIndex = (
+    contentVersionId: string,
+    index: number,
+    newTiptapJson: JSONContent,
+    newWordCount: number
+) => {
+    originalValues.update((existing) => {
+        let wordCounts = existing[contentVersionId]?.wordCounts;
+        wordCounts ||= [];
+        wordCounts[index] = newWordCount;
+        return {
+            ...existing,
+            [contentVersionId]: {
+                ...existing[contentVersionId],
+                content: existing[contentVersionId]?.content?.map((item, idx) =>
+                    idx === index ? { ...item, tiptap: newTiptapJson } : item
+                ),
+                wordCounts,
+            },
+        };
+    });
+};
+
+export const updateOriginal = (contentVersionId: string) => {
+    originalValues.update((existing) => ({
+        ...existing,
+        [contentVersionId]: { ...existing[contentVersionId], ...get(updatedValues)[contentVersionId] },
+    }));
+};
+
+export const userStoppedEditing: Writable<Record<string, boolean>> = writable({});
 
 export interface TiptapContentValues {
     content?: TiptapContentItemValues[] | undefined;

--- a/src/lib/utils/auto-save-store.ts
+++ b/src/lib/utils/auto-save-store.ts
@@ -1,0 +1,51 @@
+import { writable, get } from 'svelte/store';
+
+export function createAutosaveStore(doSave: () => Promise<void>) {
+    const isSaving = writable(false);
+    const showSavingFailed = writable(false);
+    let retryCount = 0;
+    let retryTimeout: NodeJS.Timeout | null = null;
+
+    // Save, returning whether the save happened successfully.
+    // It won't attempt a save if there's an ongoing retry loop, unless the force param is passed.
+    async function save(force = false, isRetrying = false) {
+        if (force || isRetrying || (!get(isSaving) && !retryTimeout)) {
+            isSaving.set(true);
+            try {
+                await doSave();
+                retryCount = 0;
+                retryTimeout && clearTimeout(retryTimeout);
+                retryTimeout = null;
+                return true;
+            } catch (error) {
+                if (!force) {
+                    retryCount++;
+                    if (retryCount >= 4) {
+                        showSavingFailed.set(true);
+                    } else {
+                        retryTimeout && clearTimeout(retryTimeout);
+                        retryTimeout = setTimeout(() => save(false, true), 20000);
+                    }
+                }
+            } finally {
+                isSaving.set(false);
+            }
+            return false;
+        }
+        return false;
+    }
+
+    function resetSaveState() {
+        retryCount = 0;
+        retryTimeout && clearTimeout(retryTimeout);
+        retryTimeout = null;
+        showSavingFailed.set(false);
+    }
+
+    return {
+        isSaving,
+        showSavingFailed,
+        save,
+        resetSaveState,
+    };
+}


### PR DESCRIPTION
- In order to prevent odd issues revolving around state and editor history (undo/redo), this separates
out the draft and published versions so they each live in a separate Tiptap editor.
- Additionally it updates the buttons so that auto-save works when italics or bold or whatever is
used.
- It also refactors the save-on-navigate to be more bulletproof.
- Finally, it fixes the undo and redo buttons so they're disabled when there is not history.