### PR TITLE
restrict assigning users based on companies

### DIFF
--- a/src/lib/types/base.ts
+++ b/src/lib/types/base.ts
@@ -49,7 +49,6 @@ export enum UserRole {
 export interface User extends BasicUser {
     role: UserRole;
     company: Company;
-    companyName: string;
     isEmailVerified: string;
     email: string;
 }

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -62,7 +62,7 @@
                                 <td class="p-5">{user.name}</td>
                                 <td class="p-5">{user.email}</td>
                                 <td class="p-5">{user.role}</td>
-                                <td class="p-5">{user.companyName}</td>
+                                <td class="p-5">{user.company.name}</td>
                                 <td class="p-5">{user.isEmailVerified ? 'Verified' : 'Invited'}</td>
                             </tr>
                         {/each}


### PR DESCRIPTION
- Managers should only be able to override assignments for things assigned to users in their company
- Non-publishers should only be able to assign things to people in their company