### PR TITLE
add sort by title on publisher dashboard tabs

### DIFF
--- a/src/lib/components/SortingTableHeaderCell.svelte
+++ b/src/lib/components/SortingTableHeaderCell.svelte
@@ -18,8 +18,8 @@
 <th class="cursor-pointer select-none" on:click={toggleSort}>
     {text}
     {#if determineCaret(sortKey, currentSort) === ''}
-        <span class="invisible">↑</span>
+        <span class="text-sm opacity-50">↓</span>
     {:else}
-        <span>{determineCaret(sortKey, currentSort)}</span>
+        <span class="text-sm text-gray-700">{determineCaret(sortKey, currentSort)}</span>
     {/if}
 </th>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -64,6 +64,7 @@ export interface ResourcesSummary {
 export interface ResourceAssignedToSelf {
     id: number;
     englishLabel: string;
+    languageEnglishDisplay: string;
     parentResourceName: string;
     daysSinceAssignment: number;
     wordCount: number | null;
@@ -74,6 +75,7 @@ export interface ResourcePendingReview {
     id: number;
     englishLabel: string;
     parentResourceName: string;
+    languageEnglishDisplay: string;
     daysSinceStatusChange: number;
     wordCount: number | null;
 }

--- a/src/routes/EditorDashboard.svelte
+++ b/src/routes/EditorDashboard.svelte
@@ -42,7 +42,6 @@
                     <tr class="bg-base-200">
                         <th>Title</th>
                         <th>Resource</th>
-                        <th>Status</th>
                         <SortingTableHeaderCell
                             text="Days"
                             sortKey={SORT_KEYS.days}
@@ -68,9 +67,6 @@
                                 </LinkedTableCell>
                                 <LinkedTableCell href={`/resources/${resource.id}`}>
                                     {resource.parentResourceName}
-                                </LinkedTableCell>
-                                <LinkedTableCell href={`/resources/${resource.id}`}>
-                                    {resource.status}
                                 </LinkedTableCell>
                                 <LinkedTableCell href={`/resources/${resource.id}`}>
                                     {resource.daysSinceAssignment}

--- a/src/routes/PublisherDashboard.svelte
+++ b/src/routes/PublisherDashboard.svelte
@@ -17,16 +17,22 @@
     }
 
     const SORT_KEYS = {
+        title: 'title',
+        language: 'language',
         days: 'days',
         wordCount: 'word-count',
     };
 
     const sortAssignedData = createListSorter<ResourceAssignedToSelf>({
+        [SORT_KEYS.title]: 'englishLabel',
+        [SORT_KEYS.language]: 'languageEnglishDisplay',
         [SORT_KEYS.days]: 'daysSinceAssignment',
         [SORT_KEYS.wordCount]: 'wordCount',
     });
 
     const sortPendingData = createListSorter<ResourcePendingReview>({
+        [SORT_KEYS.title]: 'englishLabel',
+        [SORT_KEYS.language]: 'languageEnglishDisplay',
         [SORT_KEYS.days]: 'daysSinceStatusChange',
         [SORT_KEYS.wordCount]: 'wordCount',
     });
@@ -73,8 +79,17 @@
                     {#if $searchParams.tab === Tab.myWork}
                         <thead>
                             <tr class="bg-base-200">
-                                <th>Title</th>
+                                <SortingTableHeaderCell
+                                    text="Title"
+                                    sortKey={SORT_KEYS.title}
+                                    bind:currentSort={$searchParams.sort}
+                                />
                                 <th>Resource</th>
+                                <SortingTableHeaderCell
+                                    text="Language"
+                                    sortKey={SORT_KEYS.language}
+                                    bind:currentSort={$searchParams.sort}
+                                />
                                 <th>Status</th>
                                 <SortingTableHeaderCell
                                     text="Days"
@@ -103,6 +118,9 @@
                                             {resource.parentResourceName}
                                         </LinkedTableCell>
                                         <LinkedTableCell href={`/resources/${resource.id}`}>
+                                            {resource.languageEnglishDisplay}
+                                        </LinkedTableCell>
+                                        <LinkedTableCell href={`/resources/${resource.id}`}>
                                             {resource.status}
                                         </LinkedTableCell>
                                         <LinkedTableCell href={`/resources/${resource.id}`}>
@@ -118,8 +136,17 @@
                     {:else if $searchParams.tab === Tab.reviewPending}
                         <thead>
                             <tr class="bg-base-200">
-                                <th>Title</th>
+                                <SortingTableHeaderCell
+                                    text="Title"
+                                    sortKey={SORT_KEYS.title}
+                                    bind:currentSort={$searchParams.sort}
+                                />
                                 <th>Resource</th>
+                                <SortingTableHeaderCell
+                                    text="Language"
+                                    sortKey={SORT_KEYS.language}
+                                    bind:currentSort={$searchParams.sort}
+                                />
                                 <SortingTableHeaderCell
                                     text="Days"
                                     sortKey={SORT_KEYS.days}
@@ -145,6 +172,9 @@
                                         </LinkedTableCell>
                                         <LinkedTableCell href={`/resources/${resource.id}`}>
                                             {resource.parentResourceName}
+                                        </LinkedTableCell>
+                                        <LinkedTableCell href={`/resources/${resource.id}`}>
+                                            {resource.languageEnglishDisplay}
                                         </LinkedTableCell>
                                         <LinkedTableCell href={`/resources/${resource.id}`}>
                                             {resource.daysSinceStatusChange}


### PR DESCRIPTION
Adds language to publisher dashboard and sorting by title/language. Also fixes the UI so it's clear what is currently being used to sort and what is not.