### PR TITLE
require svelte each blocks to have key and update existing usages

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,6 +24,7 @@ module.exports = {
     ],
     rules: {
         'svelte/no-at-html-tags': 0,
+        'svelte/require-each-key': 1,
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
         'svelte-translate-check/missing-translations': 'error',
         '@typescript-eslint/no-non-null-assertion': 'off',

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <select {disabled} class={$$props.class} on:change={handleChange} {value}>
-    {#each options as option}
+    {#each options as option (option.value)}
         <option value={option.value}>{option.label}</option>
     {/each}
 </select>

--- a/src/lib/components/projects/ProjectTable.svelte
+++ b/src/lib/components/projects/ProjectTable.svelte
@@ -92,7 +92,7 @@
 </script>
 
 <div class="grid w-full grid-cols-7 rounded-md border border-b-0">
-    {#each columns as column}
+    {#each columns as column (column.name)}
         <div class="flex items-center justify-between border-b bg-gray-50 px-4 py-3">
             <div class="text-xs font-bold">{column.label}</div>
             <div>

--- a/src/lib/components/projects/ProjectViewTable.svelte
+++ b/src/lib/components/projects/ProjectViewTable.svelte
@@ -11,13 +11,13 @@
 
 {#if $project?.items}
     <div class="grid h-auto w-full grid-cols-4">
-        {#each columns as column}
+        {#each columns as column (column.label)}
             <div class="border-b bg-gray-50 px-4 py-3 text-xs font-bold">{column.label}</div>
         {/each}
     </div>
 
     <div class="grid w-full grow grid-cols-4 overflow-auto">
-        {#each $project?.items as item}
+        {#each $project?.items as item (item.resourceContentId)}
             <a
                 href={`/resources/${item.resourceContentId}`}
                 class="flex items-center border-b px-4 py-3 text-sm text-gray-600">{item?.englishLabel ?? ''}</a

--- a/src/lib/components/projects/ProjectViewTabs.svelte
+++ b/src/lib/components/projects/ProjectViewTabs.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <div class="mt-4 flex ps-4">
-    {#each tabs as tab, index}
+    {#each tabs as tab, index (tab.name)}
         <button
             class="me-4 py-2 text-lg {tab.current ? 'border-b-4 border-primary' : ''}"
             on:click={() => setCurrentTab(index)}

--- a/src/lib/components/reporting/ReportTable.svelte
+++ b/src/lib/components/reporting/ReportTable.svelte
@@ -19,11 +19,11 @@
 </script>
 
 <div class="grid grid-cols-{columns.length} w-full rounded-md border border-b-0">
-    {#each columns as column}
+    {#each columns as column (column)}
         <div class="border-b bg-gray-50 px-4 py-3 text-xs font-bold">{formatColumnName(column)}</div>
     {/each}
-    {#each $currentListData as row}
-        {#each columns as column}
+    {#each $currentListData as row, i (i)}
+        {#each columns as column (column)}
             <div class="border-b px-4 py-3 text-sm text-gray-600">{row[column]}</div>
         {/each}
     {/each}

--- a/src/lib/components/resources/BibleReferences.svelte
+++ b/src/lib/components/resources/BibleReferences.svelte
@@ -30,7 +30,7 @@
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex w-full flex-col">
             {#if bibleReferences.length > 0}
-                {#each bibleReferences as bibleReference}
+                {#each bibleReferences as bibleReference, i (i)}
                     <div class="mb-4 flex w-full justify-between">
                         <p class="font-bold">{generateVerseFromReference(bibleReference)}</p>
                     </div>

--- a/src/lib/components/resources/LanguageDropdown.svelte
+++ b/src/lib/components/resources/LanguageDropdown.svelte
@@ -15,7 +15,7 @@
 {#if filteredLanguageSet.length > 0}
     <select on:change={onChange} class="select select-info font-semibold" disabled={disable}>
         <option value="" disabled selected>Select a Language</option>
-        {#each filteredLanguageSet as { label, contentId }}
+        {#each filteredLanguageSet as { label, contentId } (contentId)}
             <option value={contentId}>{label}</option>
         {/each}
     </select>

--- a/src/lib/components/resources/RelatedContent.svelte
+++ b/src/lib/components/resources/RelatedContent.svelte
@@ -27,7 +27,7 @@
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex flex-col">
             {#if relatedContent.length > 0}
-                {#each relatedContent as resource}
+                {#each relatedContent as resource (resource.label)}
                     <div class="mb-4 flex">
                         <div class="flex items-center">
                             <Icon data={getIcon(resource.mediaTypes[0])} scale={3} />

--- a/src/lib/components/resources/Translations.svelte
+++ b/src/lib/components/resources/Translations.svelte
@@ -23,7 +23,7 @@
     <div class="px-4 py-2 text-xl font-medium">Translations</div>
     <div class="h-full overflow-y-scroll rounded-lg bg-white p-4">
         <div class="flex flex-col">
-            {#each mappedTranslations as translation}
+            {#each mappedTranslations as translation (translation.contentId)}
                 <div class="mb-2 flex justify-between">
                     <span class="btn-link me-4 font-bold no-underline"
                         ><a href={`/resources/${translation.contentId}`}>{translation.languageName}</a></span

--- a/src/lib/components/tiptap/Tiptap.svelte
+++ b/src/lib/components/tiptap/Tiptap.svelte
@@ -251,7 +251,7 @@
             : 'top-[44px]'} z-20 flex h-16 w-[calc(100%-10px)] items-center rounded-md bg-white"
     >
         <div class="mx-6 mt-2">
-            {#each formattingOptions(currentEditor) as option}
+            {#each formattingOptions(currentEditor) as option (option.name)}
                 <button
                     class="btn btn-xs mx-1 px-0 hover:bg-[#e6f7fc] {option.disabled &&
                         '!bg-white'} {currentEditor.isActive(option.name) ? 'btn-primary' : 'btn-link'}"
@@ -261,7 +261,7 @@
                     <svelte:component this={option.icon} />
                 </button>
             {/each}
-            {#each headerLevels as header}
+            {#each headerLevels as header (header.level)}
                 <button
                     class="btn btn-xs mx-0.5 px-1 hover:bg-[#e6f7fc] {currentEditor.isActive('heading', {
                         level: header.level,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -128,7 +128,7 @@
                 <div class="flex h-full w-48 flex-col bg-neutral pb-1">
                     <div class="m-2 flex-grow-0"><img src={AquiferLogo} alt="Aquifer" /></div>
 
-                    {#each sidebarNavigation as navItem}
+                    {#each sidebarNavigation as navItem (navItem.href)}
                         {#if !navItem.hidden}
                             <div class="flex-grow-0">
                                 <a

--- a/src/routes/EditorDashboard.svelte
+++ b/src/routes/EditorDashboard.svelte
@@ -60,7 +60,7 @@
                             <td colspan="4" class="text-center">Your work is all done!</td>
                         </tr>
                     {:else}
-                        {#each sortData(resourceContents, $searchParams.sort) as resource}
+                        {#each sortData(resourceContents, $searchParams.sort) as resource (resource.contentId)}
                             <tr>
                                 <LinkedTableCell href={`/resources/${resource.contentId}`}>
                                     {resource.displayName}

--- a/src/routes/PublisherDashboard.svelte
+++ b/src/routes/PublisherDashboard.svelte
@@ -93,7 +93,7 @@
                                     <td colspan="4" class="text-center">Your work is all done!</td>
                                 </tr>
                             {:else}
-                                {#each sortAssignedData(assignedContents, $searchParams.sort) as resource}
+                                {#each sortAssignedData(assignedContents, $searchParams.sort) as resource (resource.contentId)}
                                     <tr>
                                         <LinkedTableCell href={`/resources/${resource.contentId}`}>
                                             {resource.displayName}
@@ -135,7 +135,7 @@
                                     <td colspan="4" class="text-center">No items pending review.</td>
                                 </tr>
                             {:else}
-                                {#each sortPendingData(pendingReviewContents, $searchParams.sort) as resource}
+                                {#each sortPendingData(pendingReviewContents, $searchParams.sort) as resource (resource.contentId)}
                                     <tr>
                                         <LinkedTableCell href={`/resources/${resource.contentId}`}>
                                             {resource.displayName}

--- a/src/routes/projects/new/ProjectContentSelectorTable.svelte
+++ b/src/routes/projects/new/ProjectContentSelectorTable.svelte
@@ -58,7 +58,7 @@
                 </td>
             </tr>
         {:else}
-            {#each allContent as content}
+            {#each allContent as content (content.resourceId)}
                 <tr class="cursor-pointer" on:click={() => toggleSelectedId(content.resourceId)}>
                     <td><input type="checkbox" checked={selectedIds.has(content.resourceId)} class="checkbox" /></td>
                     <td>{content.title}</td>

--- a/src/routes/reporting/+page.svelte
+++ b/src/routes/reporting/+page.svelte
@@ -119,7 +119,7 @@
     </div>
 
     <div class="mx-4 mb-12 grid grid-cols-3 gap-4">
-        {#each reportingLinkData as link}
+        {#each reportingLinkData as link (link.reportLink)}
             <ReportingLink
                 reportTitle={link.reportTitle}
                 reportDescription={link.reportDescription}

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -116,7 +116,7 @@
                     class="select select-bordered me-2 w-2/6 max-w-xs bg-base-200 pe-14 ps-4"
                 >
                     <option value={0} selected>{$translate('page.resources.dropdowns.allLanguages.value')}</option>
-                    {#each data.languages || [] as language}
+                    {#each data.languages || [] as language (language.id)}
                         <option value={language.id}>{language.englishDisplay}</option>
                     {/each}
                 </select>
@@ -127,7 +127,7 @@
                     class="select select-bordered w-2/6 max-w-xs bg-base-200 pe-14 ps-4"
                 >
                     <option value={0} selected>{$translate('page.resources.dropdowns.allResources.value')}</option>
-                    {#each data.resourceTypes || [] as resourceType}
+                    {#each data.resourceTypes || [] as resourceType (resourceType.id)}
                         <option value={resourceType.id}>{resourceType.displayName}</option>
                     {/each}
                 </select>
@@ -174,7 +174,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {#each resourceList as resource}
+                    {#each resourceList as resource, i (i)}
                         {@const contentId = calculateContentId(resource.contentIdsWithLanguageIds)}
                         <tr class="hover">
                             <LinkedTableCell href={`/resources/${contentId}`}>
@@ -211,7 +211,7 @@
                 })}
             </div>
             <select bind:value={$resourcesPerPage} class="select select-bordered select-ghost select-xs">
-                {#each [10, 50, 100] as count, i}
+                {#each [10, 50, 100] as count, i (count)}
                     <option value={count} selected={i === 0}>
                         {`${count} ${$translate('page.resources.table.navigation.perPage.value')}`}
                     </option>

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -480,7 +480,7 @@
                 <BibleReferences bibleReferences={getSortedReferences(resourceContent)} />
             </div>
             <div class="flex h-[85vh] w-8/12 flex-col">
-                {#each resourceContent.contentVersions as version, index}
+                {#each resourceContent.contentVersions as version, index (index)}
                     {@const contentVersionId = fakeContentVersionId(resourceContent, index)}
                     {#key contentVersionId}
                         <Content

--- a/src/routes/resources/[resourceContentId]/TranslationSelector.svelte
+++ b/src/routes/resources/[resourceContentId]/TranslationSelector.svelte
@@ -12,7 +12,7 @@
 {#if languagesToShow}
     <select bind:value={selectedLanguageId} class="select select-bordered">
         <option disabled value={null} selected>Select language</option>
-        {#each languagesToShow as language}
+        {#each languagesToShow as language (language.id)}
             <option value={language.id}>{language.englishDisplay}</option>
         {/each}
     </select>

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -57,7 +57,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {#each filterUsers(userData, searchVal) as user}
+                        {#each filterUsers(userData, searchVal) as user (user.email)}
                             <tr>
                                 <td class="p-5">{user.name}</td>
                                 <td class="p-5">{user.email}</td>


### PR DESCRIPTION
A bug identified on the projects page made me realize that we don't have this lint rule in place that makes Svelte's `{#each ...}` block much safer to use.