### PR TITLE
add back injected fetches to silence warnings and improve logging

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,6 +3,7 @@ import config from '$lib/config';
 import { browser } from '$app/environment';
 import { isAuthenticatedStore, profile } from './stores/auth';
 import { get } from 'svelte/store';
+import { AUTH_TOKEN_RETRIEVAL_ERROR } from './utils/http-service';
 
 const appInsights = new ApplicationInsights({
     config: {
@@ -27,7 +28,9 @@ export const log = {
         if (
             error &&
             error.message &&
-            (error.message.includes('Failed to fetch') || error.message.includes('Load failed'))
+            (error.message.includes('Failed to fetch') ||
+                error.message.includes('Load failed') ||
+                error.message.includes(AUTH_TOKEN_RETRIEVAL_ERROR))
         ) {
             console.error(error);
         } else if (error) {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -9,14 +9,14 @@ import { get } from 'svelte/store';
 
 export const ssr = false;
 
-export const load: LayoutLoad = async ({ url }) => {
+export const load: LayoutLoad = async ({ url, fetch }) => {
     await initAuth0(url);
 
     const [languages, resourceTypes, resourceContentStatuses, currentUser] = await Promise.all([
-        getFromApi<Language[]>('/languages'),
-        getFromApi<ResourceType[]>('/resources/parent-resources'),
-        getFromApi<ResourceContentStatus[]>('/admin/resources/content/statuses'),
-        getFromApi<CurrentUser>('/users/self'),
+        getFromApi<Language[]>('/languages', fetch),
+        getFromApi<ResourceType[]>('/resources/parent-resources', fetch),
+        getFromApi<ResourceContentStatus[]>('/admin/resources/content/statuses', fetch),
+        getFromApi<CurrentUser>('/users/self', fetch),
     ]);
 
     let users: User[] | null = null;
@@ -24,7 +24,7 @@ export const load: LayoutLoad = async ({ url }) => {
     setCurrentUser(currentUser);
 
     if (get(userCan)(Permission.ReadUsers)) {
-        users = await getFromApi<User[]>('/users');
+        users = await getFromApi<User[]>('/users', fetch);
     }
 
     await initI18n();

--- a/src/routes/projects/+page.ts
+++ b/src/routes/projects/+page.ts
@@ -5,11 +5,11 @@ import { Permission, userCan } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 
-export const load: PageLoad = async ({ parent }) => {
+export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
 
     if (get(userCan)(Permission.ReadProjects)) {
-        const projectListResponse = getFromApiWithoutBlocking<ProjectListResponse[]>('/projects');
+        const projectListResponse = getFromApiWithoutBlocking<ProjectListResponse[]>('/projects', fetch);
         return { projectListResponse };
     } else {
         throw redirect(302, '/');

--- a/src/routes/projects/[projectId]/+page.ts
+++ b/src/routes/projects/[projectId]/+page.ts
@@ -5,11 +5,11 @@ import { Permission, userCan } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 
-export const load: PageLoad = async ({ params, parent }) => {
+export const load: PageLoad = async ({ params, parent, fetch }) => {
     await parent();
 
     if (get(userCan)(Permission.ReadProjects)) {
-        const projectResponse = getFromApiWithoutBlocking<ProjectResponse>(`/projects/${params.projectId}`);
+        const projectResponse = getFromApiWithoutBlocking<ProjectResponse>(`/projects/${params.projectId}`, fetch);
         return { projectResponse };
     } else {
         throw redirect(302, '/');

--- a/src/routes/projects/new/+page.ts
+++ b/src/routes/projects/new/+page.ts
@@ -6,15 +6,15 @@ import { Permission, userCan } from '$lib/stores/auth';
 import { sortByKey } from '$lib/utils/sorting';
 import { get } from 'svelte/store';
 
-export const load: PageLoad = async ({ parent }) => {
+export const load: PageLoad = async ({ parent, fetch }) => {
     const { languages } = await parent();
 
     if (get(userCan)(Permission.CreateProject)) {
         const englishLanguageId = languages?.find((l) => l.iso6393Code === 'eng')?.id;
         return {
-            projectPlatforms: sortByKey(await getFromApi<ProjectPlatform[]>('/project-platforms'), 'name'),
-            companies: sortByKey(await getFromApi<Company[]>('/companies'), 'name'),
-            bibles: await getFromApi<Bible[]>(`/bibles/language/${englishLanguageId}`),
+            projectPlatforms: sortByKey(await getFromApi<ProjectPlatform[]>('/project-platforms', fetch), 'name'),
+            companies: sortByKey(await getFromApi<Company[]>('/companies', fetch), 'name'),
+            bibles: await getFromApi<Bible[]>(`/bibles/language/${englishLanguageId}`, fetch),
         };
     } else {
         throw redirect(302, '/');

--- a/src/routes/reporting/+page.ts
+++ b/src/routes/reporting/+page.ts
@@ -5,12 +5,15 @@ import { Permission, userCan } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 
-export const load: PageLoad = async ({ parent }) => {
+export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
 
     if (get(userCan)(Permission.ReadReports)) {
-        const summary = getFromApiWithoutBlocking<ResourcesSummary>('/admin/resources/summary');
-        const resourceItemsSummary = getFromApiWithoutBlocking<ResourceItemsSummary>('/reports/resources/item-totals');
+        const summary = getFromApiWithoutBlocking<ResourcesSummary>('/admin/resources/summary', fetch);
+        const resourceItemsSummary = getFromApiWithoutBlocking<ResourceItemsSummary>(
+            '/reports/resources/item-totals',
+            fetch
+        );
         return { summary, resourceItemsSummary };
     } else {
         throw redirect(302, '/');

--- a/src/routes/reporting/[monthlyReportType]/+page.ts
+++ b/src/routes/reporting/[monthlyReportType]/+page.ts
@@ -6,14 +6,15 @@ import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 import { sideBarHiddenOnPage } from '$lib/stores/app';
 
-export const load: PageLoad = async ({ params, parent }) => {
+export const load: PageLoad = async ({ params, parent, fetch }) => {
     await parent();
 
     sideBarHiddenOnPage.set(true);
 
     if (get(userCan)(Permission.ReadReports)) {
         const report = getFromApiWithoutBlocking<MonthlyStartsAndCompletions>(
-            `/reports/${params.monthlyReportType}/monthly`
+            `/reports/${params.monthlyReportType}/monthly`,
+            fetch
         );
         return {
             reportType: params.monthlyReportType,

--- a/src/routes/reporting/bar-charts/[barChartType]/+page.ts
+++ b/src/routes/reporting/bar-charts/[barChartType]/+page.ts
@@ -6,14 +6,15 @@ import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 import { sideBarHiddenOnPage } from '$lib/stores/app';
 
-export const load: PageLoad = async ({ params, parent }) => {
+export const load: PageLoad = async ({ params, parent, fetch }) => {
     await parent();
 
     sideBarHiddenOnPage.set(true);
 
     if (get(userCan)(Permission.ReadReports)) {
         const report = getFromApiWithoutBlocking<DailyResourceDownloads[]>(
-            `/reports/bar-charts/${params.barChartType}`
+            `/reports/bar-charts/${params.barChartType}`,
+            fetch
         );
         return {
             report,

--- a/src/routes/reporting/lists/[listId]/+page.ts
+++ b/src/routes/reporting/lists/[listId]/+page.ts
@@ -6,14 +6,14 @@ import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 import { sideBarHiddenOnPage } from '$lib/stores/app';
 
-export const load: PageLoad = async ({ params, parent }) => {
+export const load: PageLoad = async ({ params, parent, fetch }) => {
     await parent();
 
     sideBarHiddenOnPage.set(true);
 
     if (get(userCan)(Permission.ReadReports)) {
         const listId = params.listId;
-        const listData = getFromApiWithoutBlocking<GenericReportRow[]>(`/reports/resources/${listId}`);
+        const listData = getFromApiWithoutBlocking<GenericReportRow[]>(`/reports/resources/${listId}`, fetch);
         return {
             listData,
             listId,

--- a/src/routes/resources/+layout.ts
+++ b/src/routes/resources/+layout.ts
@@ -8,6 +8,6 @@ export const load: LayoutLoad = async ({ parent }) => {
     const englishLanguageId = languages?.find((l) => l.iso6393Code === 'eng')?.id;
 
     return {
-        bibles: getFromApiWithoutBlocking<Bible[]>(`/bibles/language/${englishLanguageId}`),
+        bibles: getFromApiWithoutBlocking<Bible[]>(`/bibles/language/${englishLanguageId}`, fetch),
     };
 };

--- a/src/routes/resources/+page.ts
+++ b/src/routes/resources/+page.ts
@@ -36,7 +36,7 @@ export const load: PageLoad = async ({ url, fetch }) => {
 };
 
 function getResourceContents(
-    fetch: typeof window.fetch,
+    injectedFetch: typeof window.fetch,
     currentPage: number,
     limit: number,
     languageId: number,
@@ -65,7 +65,7 @@ function getResourceContents(
         return null;
     }
 
-    return getFromApiWithoutBlocking<ResourceContentResponse>(`/resources/content?${queryString}`);
+    return getFromApiWithoutBlocking<ResourceContentResponse>(`/resources/content?${queryString}`, injectedFetch);
 }
 
 export interface ResourceContentResponse {

--- a/src/routes/resources/[resourceContentId]/+page.ts
+++ b/src/routes/resources/[resourceContentId]/+page.ts
@@ -2,9 +2,12 @@ import type { PageLoad } from './$types';
 import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
 import type { ResourceContent } from '$lib/types/resources';
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ params, fetch }) => {
     return {
         resourceContentId: params.resourceContentId,
-        resourceContent: getFromApiWithoutBlocking<ResourceContent>(`/resources/content/${params.resourceContentId}`),
+        resourceContent: getFromApiWithoutBlocking<ResourceContent>(
+            `/resources/content/${params.resourceContentId}`,
+            fetch
+        ),
     };
 };

--- a/src/routes/resources/[resourceContentId]/simplify/+page.ts
+++ b/src/routes/resources/[resourceContentId]/simplify/+page.ts
@@ -1,18 +1,19 @@
-﻿import type { PageLoad } from '../$types';
+import type { PageLoad } from '../$types';
 import { Permission, userCan } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
 import type { ResourceContent } from '$lib/types/resources';
 
-export const load: PageLoad = async ({ parent, params, url }) => {
+export const load: PageLoad = async ({ parent, params, url, fetch }) => {
     await parent();
     if (get(userCan)(Permission.AiSimplify)) {
         return {
             versionId: url.searchParams.get('v'),
             resourceContentId: params.resourceContentId,
             resourceContent: getFromApiWithoutBlocking<ResourceContent>(
-                `/resources/content/${params.resourceContentId}`
+                `/resources/content/${params.resourceContentId}`,
+                fetch
             ),
         };
     } else {

--- a/src/routes/users/+page.ts
+++ b/src/routes/users/+page.ts
@@ -5,12 +5,12 @@ import type { PageLoad } from './$types';
 import { type User, type Company, UserRole } from '$lib/types/base';
 import { get } from 'svelte/store';
 
-export const load: PageLoad = async ({ parent }) => {
+export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
 
     if (get(userCan)(Permission.CreateUser) || get(userCan)(Permission.CreateUserInCompany)) {
-        const userData = getFromApiWithoutBlocking<User[]>(`/users`);
-        const companies = getFromApiWithoutBlocking<Company[]>(`/companies`);
+        const userData = getFromApiWithoutBlocking<User[]>(`/users`, fetch);
+        const companies = getFromApiWithoutBlocking<Company[]>(`/companies`, fetch);
         const roles = [UserRole.Editor, UserRole.Manager];
         return {
             userData,


### PR DESCRIPTION
For whatever reason, even though the injected `fetch` inside `+page.ts` files is only relevant to SSR, when you disable SSR you continue to get warnings about not using it. To fix this we'll just add it back in, since it's not hurting anything.

Also improves a couple logging areas so we aren't getting extra logs.