### PR TITLE
update htmldiff-ts to handle paragraph splitting and merging

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@tiptap/starter-kit": "^2.1.12",
         "chart.js": "^4.4.0",
         "daisyui": "^4.6.0",
-        "htmldiff-ts": "BiblioNexusStudio/htmldiff-ts#1.0.2",
+        "htmldiff-ts": "BiblioNexusStudio/htmldiff-ts#1.0.3",
         "svelte": "^4.0.5",
         "svelte-awesome": "^3.2.1",
         "svelte-i18n": "^3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,9 +3164,9 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
-htmldiff-ts@BiblioNexusStudio/htmldiff-ts#1.0.2:
+htmldiff-ts@BiblioNexusStudio/htmldiff-ts#1.0.3:
   version "1.0.0"
-  resolved "git+ssh://git@github.com/BiblioNexusStudio/htmldiff-ts.git#fb8daacff13a2e1993884c09f5c726e6910c6666"
+  resolved "git+ssh://git@github.com/BiblioNexusStudio/htmldiff-ts.git#592935aece82ca0f8ffc072c51733bf5e57042b5"
   dependencies:
     striptags "^3.2.0"
 


### PR DESCRIPTION
There are now `¶` icons that are shown in red or green depending on if you deleted the paragraph break or added a new paragraph break.

![image](https://github.com/BiblioNexusStudio/content-manager-web/assets/4652012/412072fb-98bd-4d00-bc56-edbb54a89b4d)
