### PR TITLE
don't reset diffed html if base content doesn't change

### DIFF
--- a/src/lib/components/editor/TiptapDiffRenderer.svelte
+++ b/src/lib/components/editor/TiptapDiffRenderer.svelte
@@ -24,8 +24,11 @@
 
     async function calculateBaseHtmlWithTextDirection(tiptapJson: TiptapContentItem | undefined) {
         if (tiptapJson) {
-            diffedHtml = undefined;
+            const original = baseHtmlWithTextDirection;
             baseHtmlWithTextDirection = await getHtmlWithTextDirection(tiptapJson);
+            if (original !== baseHtmlWithTextDirection) {
+                diffedHtml = undefined;
+            }
         }
     }
 


### PR DESCRIPTION
When switching between two identical versions, we were resetting the diffed HTML but the optimization baked into the differ was skipping the recalculation so the diffed HTML was gone and never got updated. This addresses it by only resetting the diffed HTML if the base HTML has changed.