### PR TITLE
Fix truncate on project name in translations dropdown

### DIFF
--- a/src/lib/components/resources/menus/CurrentTranslations.svelte
+++ b/src/lib/components/resources/menus/CurrentTranslations.svelte
@@ -65,9 +65,9 @@
             {/if}
             {#if project}
                 <div class="mb-4 flex items-center justify-between px-4">
-                    <span class="text-lg font-bold">Project:</span><span
-                        class="btn-link ms-8 flex w-72 justify-end truncate text-lg font-bold no-underline"
-                        ><a href={`/projects/${project.id}`}>{project.name}</a></span
+                    <span class="text-lg font-bold">Project:</span>
+                    <span class="btn-link ms-8 flex w-72 justify-end text-lg font-bold no-underline"
+                        ><a href={`/projects/${project.id}`} class="truncate">{project.name}</a></span
                     >
                 </div>
             {/if}


### PR DESCRIPTION
Before:

![image](https://github.com/BiblioNexusStudio/content-manager-web/assets/138067194/39c7d814-b6dd-4252-a5b6-077b6b129655)

After:

![image](https://github.com/BiblioNexusStudio/content-manager-web/assets/138067194/e42aa862-5f1f-4318-8120-7fb4827b0f54)
