### PR TITLE
Hotfix for BIB-539. Whenever `allTabContents` would get set, that wou…

### DIFF
--- a/src/lib/components/SortingTableHeaderCell.svelte
+++ b/src/lib/components/SortingTableHeaderCell.svelte
@@ -2,6 +2,9 @@
     export let text: string;
     export let sortKey: string;
     export let currentSort: string;
+    export let toggleSortCallback: () => void = () => {
+        return;
+    };
 
     const determineCaret = (sortKey: string, currentSort: string): string => {
         if (currentSort === sortKey) return '↑';
@@ -12,6 +15,8 @@
     function toggleSort() {
         const isAscending = currentSort === sortKey;
         currentSort = isAscending ? '-' + sortKey : sortKey;
+
+        toggleSortCallback();
     }
 </script>
 

--- a/src/routes/ManagerDashboard.svelte
+++ b/src/routes/ManagerDashboard.svelte
@@ -162,7 +162,11 @@
     }
 
     let scrollingDiv: HTMLDivElement | undefined;
-    $: $searchParams.sort && scrollingDiv && (scrollingDiv.scrollTop = 0);
+    const toggleSortCallback = () => {
+        if (scrollingDiv) {
+            scrollingDiv.scrollTop = 0;
+        }
+    };
 </script>
 
 {#await loadContents()}
@@ -249,11 +253,13 @@
                                 text="Deadline (Days)"
                                 sortKey={SORT_KEYS.days}
                                 bind:currentSort={$searchParams.sort}
+                                {toggleSortCallback}
                             />
                             <SortingTableHeaderCell
                                 text="Word Count"
                                 sortKey={SORT_KEYS.wordCount}
                                 bind:currentSort={$searchParams.sort}
+                                {toggleSortCallback}
                             />
                         </tr>
                     </thead>
@@ -309,11 +315,13 @@
                                 text="Deadline (Days)"
                                 sortKey={SORT_KEYS.days}
                                 bind:currentSort={$searchParams.sort}
+                                {toggleSortCallback}
                             />
                             <SortingTableHeaderCell
                                 text="Word Count"
                                 sortKey={SORT_KEYS.wordCount}
                                 bind:currentSort={$searchParams.sort}
+                                {toggleSortCallback}
                             />
                         </tr>
                     </thead>


### PR DESCRIPTION
…ld cause `$searchParams.sort` to update, which would cause the scroll to top to fire.