### PR TITLE
ignore resize errors instead of logging to App Insights

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -48,10 +48,15 @@ export const log = {
 
             let logToAppInsights = true;
 
-            if (
+            const ignoredFetchError =
                 'isFetchError' in error &&
-                (error.message.includes('Failed to fetch') || error.message.includes('Load failed'))
-            ) {
+                (error.message.includes('Failed to fetch') || error.message.includes('Load failed'));
+
+            const ignoredResizeError = error.message.includes(
+                'ResizeObserver loop completed with undelivered notifications'
+            );
+
+            if (ignoredFetchError || ignoredResizeError) {
                 logToAppInsights = false;
             }
 


### PR DESCRIPTION
Prevents this irrelevant error from getting logged: `ErrorEvent: ResizeObserver loop completed with undelivered notifications.`