### PR TITLE
prevent overflow when AI rating stars are on editor toolbar

### DIFF
--- a/src/lib/components/editor/AiTranslateToolbarButton.svelte
+++ b/src/lib/components/editor/AiTranslateToolbarButton.svelte
@@ -21,6 +21,10 @@
     export let isLoading: boolean;
     export let canEdit: boolean;
     export let machineTranslationStore: MachineTranslationStore;
+    export let innerElement: HTMLElement | null = null;
+    export let renderedWidth = 0;
+
+    $: renderedWidth = innerElement?.offsetWidth ?? 0;
 
     const canShowAnything =
         canEdit &&
@@ -139,7 +143,7 @@
 
 {#if showTranslateButton}
     {#if isTranslating}
-        <div class="flex w-[42px] justify-center">
+        <div bind:this={innerElement} class="flex w-[42px] justify-center">
             <div class="loading loading-infinity loading-md text-primary" />
         </div>
     {:else}
@@ -149,6 +153,7 @@
             text="Translate with AI"
         >
             <button
+                bind:this={innerElement}
                 data-app-insights-event-name="editor-toolbar-translate-click"
                 class="btn btn-link !no-animation btn-xs !bg-base-200 text-xl !no-underline"
                 disabled={$isPageTransacting}
@@ -157,7 +162,7 @@
         </Tooltip>
     {/if}
 {:else if showRating}
-    <div class="mx-2">
+    <div bind:this={innerElement} class="mx-2">
         <MachineTranslationRating {machineTranslationStore} />
     </div>
 {/if}

--- a/src/lib/components/editor/EditorToolbar.svelte
+++ b/src/lib/components/editor/EditorToolbar.svelte
@@ -29,6 +29,8 @@
     export let isLoading: boolean;
     export let machineTranslationStore: MachineTranslationStore;
 
+    let aiButtonWidth: number;
+
     const isPageTransacting = getIsPageTransactingContext();
 
     let outerDiv: HTMLDivElement | null = null;
@@ -196,13 +198,14 @@
         {@const commentOptions = getCommentOptions(editor)}
         <div class="flex space-x-2">
             {#if canEdit}
-                {#if outerDivWidth && outerDivWidth < 500}
-                    <div class="dropdown-start dropdown dropdown-bottom">
+                {#if outerDivWidth && outerDivWidth < 475 + aiButtonWidth}
+                    <div class="dropdown-start dropdown">
                         <div tabindex="0" role="button" class="btn btn-link btn-xs m-1"><MenuIcon /></div>
                         <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
                         <ul
                             tabindex="0"
-                            class="menu dropdown-content z-50 space-y-2 rounded-box bg-base-100 p-2 shadow"
+                            class="dropdown-content menu-horizontal z-50 h-auto min-h-0 items-center space-x-2
+                            rounded-box bg-base-100 p-2 pb-1 pt-3 shadow"
                         >
                             {#each formattingOptions(editor) as option (option.name)}
                                 {@const disable = option.disabled || $isPageTransacting}
@@ -268,6 +271,7 @@
         </div>
         <div class="flex">
             <AiTranslateToolbarButton
+                bind:renderedWidth={aiButtonWidth}
                 {editor}
                 {canEdit}
                 {editableDisplayNameStore}


### PR DESCRIPTION
Also makes the menu horizontal instead of vertical.

![image](https://github.com/user-attachments/assets/d421d865-f248-4325-8143-8f7f6c6e26da)
