### PR TITLE
fix table rendering issue

### DIFF
--- a/src/lib/components/Table.svelte
+++ b/src/lib/components/Table.svelte
@@ -69,7 +69,7 @@
         </tr>
     </thead>
     <tbody>
-        {#each items as item, index (index)}
+        {#each items as item (item['id'])}
             {@const href = itemUrlPrefix && `${itemUrlPrefix}${item['id'] ?? ''}`}
             <tr class="hover">
                 {#if enableSelectAll || enableSelect}


### PR DESCRIPTION
The table component was using an index-based `each` key which meant data getting swapped out could cause stale cells to be rendered. This was causing the project status bars to incorrectly display when switching tabs or sorting.