### PR TITLE
Fixes Long Titles And Empty Tables After Filters Return No Results

### DIFF
--- a/src/lib/components/projects/ProjectOverview.svelte
+++ b/src/lib/components/projects/ProjectOverview.svelte
@@ -36,7 +36,7 @@
 >
     <div class="flex flex-col">
         <ViewTabSlot title="Title">
-            <div>{$project?.name ?? ''}</div>
+            <div class="w-2/3 text-end">{$project?.name ?? ''}</div>
         </ViewTabSlot>
         <ViewTabSlot title="Language">
             <div>{$project?.language ?? ''}</div>

--- a/src/lib/components/projects/ProjectViewTableAndFilters.svelte
+++ b/src/lib/components/projects/ProjectViewTableAndFilters.svelte
@@ -70,6 +70,7 @@
             searchable={false}
             bind:searchParams={$searchParams}
             itemUrlPrefix="/resources/"
+            noItemsText="No items found."
             let:item
             let:href
             let:itemKey

--- a/src/routes/projects/[projectId]/+page.svelte
+++ b/src/routes/projects/[projectId]/+page.svelte
@@ -84,7 +84,7 @@
     <CenteredSpinnerFullScreen />
 {:then projectResponse}
     <div class="flex justify-between p-4 pb-0 xl:mb-4">
-        <div class="flex items-center">
+        <div class="flex w-2/3 items-center">
             <BackButton defaultPathIfNoHistory="/projects" />
             <span class="ms-2 text-2xl">
                 {projectResponse.company} - {projectResponse.name}


### PR DESCRIPTION
Long title issues:
<img width="1718" alt="Screenshot 2024-08-15 at 10 52 10 AM" src="https://github.com/user-attachments/assets/fe89e725-d238-4f3c-9905-f7706401c81e">

Long title issues:
<img width="843" alt="Screenshot 2024-08-15 at 10 52 47 AM" src="https://github.com/user-attachments/assets/983311a0-7cfe-4c82-9b59-6d80150f5fc0">

Your work is all done! will now say No Projects Found.
<img width="841" alt="Screenshot 2024-08-15 at 10 53 13 AM" src="https://github.com/user-attachments/assets/4ce1e3e7-b7b8-40ee-8103-d63ad73a6f95">
