### PR TITLE
add initial loading spinner instead of plain white screen

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,9 +4,46 @@
         <meta charset="utf-8" />
         <link rel="icon" href="%sveltekit.assets%/favicon.png" />
         <meta name="viewport" content="width=device-width" />
+        <style>
+            #svelte-loading-spinner {
+                color: #101828;
+                display: flex;
+                width: 100vw;
+                height: 100vh;
+            }
+
+            #svelte-loading-spinner .spinner {
+                pointer-events: none;
+                display: inline-block;
+                aspect-ratio: 1 / 1;
+                width: 1.5rem;
+                margin-left: auto;
+                margin-right: auto;
+                background-color: black;
+                mask-size: 100%;
+                mask-repeat: no-repeat;
+                mask-position: center;
+                mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' stroke='%23000' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E.spinner_V8m1%7Btransform-origin:center;animation:spinner_zKoa 2s linear infinite%7D.spinner_V8m1 circle%7Bstroke-linecap:round;animation:spinner_YpZS 1.5s ease-out infinite%7D%40keyframes spinner_zKoa%7B100%25%7Btransform:rotate(360deg)%7D%7D%40keyframes spinner_YpZS%7B0%25%7Bstroke-dasharray:0 150;stroke-dashoffset:0%7D47.5%25%7Bstroke-dasharray:42 150;stroke-dashoffset:-16%7D95%25%2C100%25%7Bstroke-dasharray:42 150;stroke-dashoffset:-59%7D%7D%3C%2Fstyle%3E%3Cg class='spinner_V8m1'%3E%3Ccircle cx='12' cy='12' r='9.5' fill='none' stroke-width='3'%3E%3C%2Fcircle%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+            }
+
+            #svelte-app-div {
+                display: none;
+            }
+        </style>
         %sveltekit.head%
     </head>
-    <body data-svteelkit-preload-data="tap" class="h-full">
-        <div style="display: contents">%sveltekit.body%</div>
+
+    <body data-sveltekit-preload-data="tap" class="h-full">
+        <div id="svelte-loading-spinner">
+            <span class="spinner"></span>
+        </div>
+        <div id="svelte-app-div">%sveltekit.body%</div>
     </body>
+
+    <script>
+        window.addEventListener('svelte-app-loaded', function () {
+            document.getElementById('svelte-loading-spinner').style.display = 'none';
+            document.getElementById('svelte-app-div').style.display = 'contents';
+        });
+    </script>
 </html>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
     import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
     import config from '$lib/config';
     import type { CurrentUser } from '$lib/types/base';
+    import { onMount } from 'svelte';
 
     $: userFullName = $profile?.name ?? ' '; // set to avoid flashing undefined
 
@@ -108,6 +109,10 @@
             element = element.parentNode as HTMLElement;
         }
     }
+
+    onMount(() => {
+        window.dispatchEvent(new Event('svelte-app-loaded')); // tell the app.html to show the page
+    });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Rather than showing any sort of loading indicator, we were previously just showing a blank white screen and on longer loads it seemed like the page was broken. This way the user knows something is happening.