### PR TITLE
pin GitHub Action versions

### DIFF
--- a/.github/actions/build-and-deploy-to-env/action.yml
+++ b/.github/actions/build-and-deploy-to-env/action.yml
@@ -45,7 +45,7 @@ runs:
               GITHUB_TOKEN: ${{ inputs.github-token }}
               LINEAR_API_KEY: ${{ inputs.linear-api-key }}
         - name: Use Node.js
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v4.0.3
           with:
               node-version: 18.16.0
               cache: yarn

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -36,7 +36,7 @@ jobs:
             url: ${{ steps.deploy.outputs.deployed-url }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - uses: ./.github/actions/build-and-deploy-to-env
               id: deploy
               with:
@@ -55,7 +55,7 @@ jobs:
             url: ${{ steps.deploy.outputs.deployed-url }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - uses: ./.github/actions/build-and-deploy-to-env
               id: deploy
               with:
@@ -77,7 +77,7 @@ jobs:
             url: ${{ steps.deploy.outputs.deployed-url }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - uses: ./.github/actions/build-and-deploy-to-env
               id: deploy
               with:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -11,11 +11,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - name: Use Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v4.0.3
               with:
                   node-version: 18.16.0
                   cache: yarn
@@ -40,7 +40,7 @@ jobs:
             url: ${{ steps.deploy.outputs.deployed-url }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/build-and-deploy-to-env


### PR DESCRIPTION
To make builds/deployments fully reproducible and avoid untimely failures this pins all GitHub Action versions.