### PR TITLE
Bib 713 add option for editor scrolling to stay synced

### DIFF
--- a/src/lib/components/editor/TiptapDiffRenderer.svelte
+++ b/src/lib/components/editor/TiptapDiffRenderer.svelte
@@ -1,5 +1,5 @@
 ﻿<script lang="ts">
-    import { onDestroy, tick } from 'svelte';
+    import { onDestroy, onMount, tick } from 'svelte';
     import type { TiptapContentItem } from '$lib/types/resources';
     import HtmlDiffWorker from '../../../workers/html-differ.ts?worker';
     import CenteredSpinner from '../CenteredSpinner.svelte';
@@ -114,6 +114,12 @@
             $scrollPosition = Math.round((scrollTop / (scrollHeight - clientHeight)) * 10000) / 10000;
         }
     };
+
+    onMount(async () => {
+        if (scrollSyncElement) {
+            scrollSyncElement.scrollTop = 0;
+        }
+    });
 
     onDestroy(() => diffWorker && diffWorker.terminate());
 </script>

--- a/src/lib/components/editor/TiptapRenderer.svelte
+++ b/src/lib/components/editor/TiptapRenderer.svelte
@@ -62,6 +62,10 @@
     }
 
     onMount(async () => {
+        if (scrollSyncElement) {
+            scrollSyncElement.scrollTop = 0;
+        }
+
         editor = new Editor({
             element,
             editable: canEdit,

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -29,7 +29,7 @@
     import { Icon } from 'svelte-awesome';
     import TranslationSelector from './TranslationSelector.svelte';
     import { createAutosaveStore } from '$lib/utils/auto-save-store';
-    import { onDestroy } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
     import Modal from '$lib/components/Modal.svelte';
     import createChangeTrackingStore from '$lib/utils/change-tracking-store';
     import { get, type Readable, type Writable } from 'svelte/store';
@@ -256,6 +256,12 @@
         }
 
         $scrollPosition = 0;
+    });
+
+    onMount(() => {
+        if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual';
+        }
     });
 
     onDestroy(resetSaveState);


### PR DESCRIPTION
Two bug fixes:
- ensure that Firefox and Edge browsers do not use scroll history by implementing `history.scrollRestoration = 'manual';` in the `onMount` for the `/resources/[resourceId]` page component.
- ensure that any time a component that uses the scrollSync feature is initialized, it'd scrollTop value is reset.