### PR TITLE
Daisyui focus button on resource page not working in Safari

### DIFF
--- a/src/lib/components/resources/menus/CurrentTranslations.svelte
+++ b/src/lib/components/resources/menus/CurrentTranslations.svelte
@@ -33,13 +33,17 @@
 </script>
 
 <div class="dropdown ms-2">
-    <button class="btn btn-ghost flex flex-nowrap px-1 hover:bg-[#e6f6fc]">
+    <button tabindex="0" class="btn btn-ghost flex flex-nowrap px-1 hover:bg-[#e6f6fc]">
         <span data-app-insights-event-name="translations-menu-click">Translations</span>
         <span class="flex h-6 w-6 items-center justify-center rounded-full border border-blue-300 bg-blue-50"
             >{numberOfTranslations}</span
         >
     </button>
-    <div class="menu dropdown-content z-[1] mt-4 flex w-auto flex-col rounded-box border bg-base-100 px-4 pt-4 shadow">
+    <div
+        role="button"
+        tabindex="0"
+        class="menu dropdown-content z-[1] mt-4 flex w-auto flex-col rounded-box border bg-base-100 px-4 pt-4 shadow"
+    >
         {#if canCreateTranslation && englishTranslation?.hasPublished && languages.length !== translations.length}
             <div class="mb-4 mt-2 flex flex-col place-items-end border-y px-4 py-3">
                 <button

--- a/src/lib/components/resources/menus/Related.svelte
+++ b/src/lib/components/resources/menus/Related.svelte
@@ -24,12 +24,17 @@
 
 <div class="dropdown ms-1">
     <button
+        tabindex="0"
         class="btn btn-ghost ms-2 whitespace-nowrap px-1 hover:bg-[#e6f6fc]"
         data-app-insights-event-name="related-content-menu-click"
     >
         Related Content
     </button>
-    <div class="menu dropdown-content z-[1] mt-4 max-h-72 w-auto rounded-box border bg-base-100 pt-4 shadow">
+    <div
+        role="button"
+        tabindex="0"
+        class="menu dropdown-content z-[1] mt-4 max-h-72 w-auto rounded-box border bg-base-100 pt-4 shadow"
+    >
         <div class="flex flex-col overflow-y-auto px-8">
             {#each relatedContent as resource, i (i)}
                 <div class="mb-4 me-2 flex">


### PR DESCRIPTION
The `Translations` and `Related Content` buttons did not work in Safari.
The fix was to add `tabindex` and `role` to the related elements.
An alternate fix is to use the `<details><summary>` [version of the dropdown](https://daisyui.com/components/dropdown/).