### PR TITLE
add support for handling missing translation ratings when assigning Fia content to new user

### DIFF
--- a/src/lib/components/MachineTranslationRating.svelte
+++ b/src/lib/components/MachineTranslationRating.svelte
@@ -4,13 +4,29 @@
     import type { MachineTranslation } from '$lib/types/resources';
     import type { MachineTranslationStore } from '$lib/stores/machineTranslation';
 
-    export let itemIndex: number;
+    export let itemIndex: number | null = null;
     export let machineTranslationStore: MachineTranslationStore;
     export let showingInPrompt = false;
     export let improvementHorizontalPositionPx = 60;
 
     let store = machineTranslationStore.machineTranslations;
-    $: machineTranslation = $store.get(itemIndex)!;
+    let machineTranslation: MachineTranslation = {
+        id: 0,
+        contentIndex: 0,
+        userId: 0,
+        userRating: 0,
+        improveClarity: false,
+        improveConsistency: false,
+        improveTone: false,
+    };
+    let translationsMissingRatings: MachineTranslation[] | null = null;
+
+    function syncMachineTranslationFromStore(store: Map<number, MachineTranslation>) {
+        if (itemIndex !== null) {
+            machineTranslation = store.get(itemIndex)!;
+        }
+    }
+
     let promptForRating = machineTranslationStore.promptForRating;
     let showImprovements = false;
     let showImprovementsDiv: HTMLDivElement;
@@ -18,6 +34,9 @@
     let ratedFromPrompt = false;
     let currentComponentUpdating = false; // needed since we have multiple MachineTranslationRating components on one page
 
+    // if promptForRating is set we'll need to recalculate translationsMissingRatings
+    $: $promptForRating && (translationsMissingRatings = null);
+    $: syncMachineTranslationFromStore($store);
     $: updateMachineTranslation(machineTranslation);
 
     async function updateMachineTranslation(data: MachineTranslation) {
@@ -30,13 +49,46 @@
             return;
         }
 
-        machineTranslationStore.debounce(async () => {
-            await patchToApi(`/resources/content/machine-translation/${machineTranslation.id}`, { ...data });
-        });
-        machineTranslationStore.machineTranslations.update((machineTranslations) =>
-            machineTranslations.set(itemIndex, data)
-        );
+        if (showingInPrompt) {
+            translationsMissingRatings ||= [...$store.values()].filter((mt) => !mt.userRating);
+            machineTranslationStore.debounce(async () => {
+                await Promise.all(
+                    translationsMissingRatings!.map((mt) =>
+                        patchToApi(`/resources/content/machine-translation/${mt.id}`, { ...data })
+                    )
+                );
+            });
+            machineTranslationStore.machineTranslations.update((machineTranslations) => {
+                for (const translation of translationsMissingRatings!) {
+                    machineTranslations.set(
+                        translation.contentIndex,
+                        mergeDataIntoMachineTranslation(data, translation)
+                    );
+                }
+                return machineTranslations;
+            });
+        } else {
+            machineTranslationStore.debounce(async () => {
+                await patchToApi(`/resources/content/machine-translation/${machineTranslation.id}`, { ...data });
+            });
+            machineTranslationStore.machineTranslations.update((machineTranslations) =>
+                machineTranslations.set(
+                    itemIndex!,
+                    mergeDataIntoMachineTranslation(data, machineTranslations.get(itemIndex!)!)
+                )
+            );
+        }
         currentComponentUpdating = false;
+    }
+
+    function mergeDataIntoMachineTranslation(data: MachineTranslation, machineTranslation: MachineTranslation) {
+        return {
+            ...machineTranslation,
+            userRating: data.userRating,
+            improveClarity: data.improveClarity,
+            improveConsistency: data.improveConsistency,
+            improveTone: data.improveTone,
+        } as MachineTranslation;
     }
 
     const onRating = async (e: MouseEvent, newRating: number) => {
@@ -48,7 +100,7 @@
         if (showingInPrompt) {
             ratedFromPrompt = true;
         } else {
-            $promptForRating = false;
+            $promptForRating = [...$store.values()].some((mt) => !mt.userRating);
         }
     };
 
@@ -56,7 +108,7 @@
         if (showImprovementsDiv) {
             showImprovements = showImprovementsDiv.contains(e.target as Node);
         } else if (ratedFromPrompt) {
-            $promptForRating = false;
+            $promptForRating = [...$store.values()].some((mt) => !mt.userRating);
         }
     };
 

--- a/src/lib/components/editor/AiTranslateToolbarButton.svelte
+++ b/src/lib/components/editor/AiTranslateToolbarButton.svelte
@@ -138,18 +138,18 @@
             content: editor.getHTML(),
         });
 
-        machineTranslationStore.promptForRating.set(true);
         machineTranslationStore.machineTranslations.update((machineTranslations) =>
             machineTranslations.set(itemIndex, {
                 id: response!.id,
                 userId: $currentUser!.id,
-                contentIndex: 0,
+                contentIndex: itemIndex,
                 userRating: 0,
                 improveClarity: false,
                 improveConsistency: false,
                 improveTone: false,
             })
         );
+        machineTranslationStore.promptForRating.set(true);
     }
 </script>
 

--- a/src/lib/types/resources.ts
+++ b/src/lib/types/resources.ts
@@ -165,7 +165,7 @@ export interface Project {
 export interface MachineTranslation {
     id: number;
     userId: number;
-    contentIndex: 0;
+    contentIndex: number;
     userRating?: number;
     improveClarity?: boolean;
     improveTone?: boolean;

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -58,7 +58,6 @@
     let commentStores: CommentStores;
     let commentThreads: Writable<CommentThreadsResponse | null>;
     let removeAllInlineThreads: Readable<() => void>;
-    let promptForMachineTranslationRating: Writable<boolean>;
 
     let errorModal: HTMLDialogElement;
     let autoSaveErrorModal: HTMLDialogElement;
@@ -114,8 +113,7 @@
     $: hasUnresolvedThreads = $commentThreads?.threads.some((x) => !x.resolved && x.id !== -1) || false;
 
     const machineTranslationStore = createMachineTranslationStore();
-    const machineTranslations = machineTranslationStore.machineTranslations;
-    $: firstMachineTranslation = $machineTranslations.get(0);
+    const promptForMachineTranslationRating = machineTranslationStore.promptForRating;
 
     async function handleFetchedResource(resourceContentPromise: Promise<ResourceContent>) {
         resourceContent = await resourceContentPromise;
@@ -214,11 +212,12 @@
         editableDisplayNameStore.setOriginalAndCurrent(resourceContent.displayName);
 
         machineTranslationStore.resetStore();
-        promptForMachineTranslationRating = machineTranslationStore.promptForRating;
-        const machineTranslationsMap = new Map(resourceContent.machineTranslations.map((mt) => [mt.contentIndex, mt]));
-        machineTranslationStore.machineTranslations.set(machineTranslationsMap);
-        firstMachineTranslation = machineTranslationsMap.get(0);
-        promptForMachineTranslationRating.set(!firstMachineTranslation?.userRating);
+        machineTranslationStore.machineTranslations.set(
+            new Map(resourceContent.machineTranslations.map((mt) => [mt.contentIndex, mt]))
+        );
+        promptForMachineTranslationRating.set(
+            resourceContent.machineTranslations.some((mt) => !mt.userRating && $userIsEqual(mt.userId))
+        );
 
         commentStores = createCommentStores();
         commentThreads = commentStores.commentThreads;
@@ -854,12 +853,11 @@
                     Choose an Editor
                 {/if}
             </h3>
-            {#if $promptForMachineTranslationRating && $userIsEqual(firstMachineTranslation?.userId) && (!Array.isArray(resourceContent?.content) || resourceContent?.content.length === 1)}
+            {#if $promptForMachineTranslationRating}
                 <div class="mb-8 flex flex-col justify-start gap-4">
                     <div class="font-semibold text-error">Please rate the AI translation before reassigning.</div>
                     <div>
                         <MachineTranslationRating
-                            itemIndex={0}
                             {machineTranslationStore}
                             showingInPrompt={true}
                             improvementHorizontalPositionPx={0}


### PR DESCRIPTION
When there are translated Fia steps that haven't been rated yet, the user will be prompted in the assign modal to rate it. All unrated translations will be rated at once.