### PR TITLE
Bib 710 modify view edit page for community reviewer users

### DIFF
--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -67,6 +67,7 @@ export enum Permission {
     ReadAllUsers = 'read:all-users',
     ReviewContent = 'review:content',
     SendReviewContent = 'send-review:content',
+    SendReviewCommunityContent = 'send-review:community-content',
     ReadCompanyContentAssignments = 'read:company-content-assignments',
     AiSimplify = 'ai:simplify',
     AiTranslate = 'ai:translate',

--- a/src/lib/types/base.ts
+++ b/src/lib/types/base.ts
@@ -84,6 +84,8 @@ export interface CurrentUser extends BasicUser {
     permissions: Permission[];
     roles: UserRole[];
     company: { id: number };
+    languageId: number | null;
+    hasAssignedContent: boolean;
 }
 
 export interface BibleBook {

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -539,13 +539,10 @@
     }
 
     async function handleCommunityTranslate() {
-        if (!$currentUser) {
-            return window.location.reload();
-        }
-
         $isPageTransacting = true;
 
-        newTranslationLanguageId = $currentUser.languageId;
+        newTranslationLanguageId = $currentUser?.languageId ?? null;
+
         await createTranslation();
     }
 

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -242,7 +242,7 @@
         canCommunityTranslate =
             $userCan(Permission.CreateCommunityContent) &&
             !resourceContent.contentTranslations.find((x) => x.languageId === $currentUser?.languageId) &&
-            resourceContent.status == ResourceContentStatusEnum.Complete &&
+            resourceContent.hasPublishedVersion === true &&
             $currentUser?.hasAssignedContent === false;
 
         canCommunitySendToPublisher =

--- a/src/routes/resources/[resourceContentId]/TranslationSelector.svelte
+++ b/src/routes/resources/[resourceContentId]/TranslationSelector.svelte
@@ -4,7 +4,7 @@
 
     export let allLanguages: Language[];
     export let existingTranslations: ContentTranslation[];
-    export let selectedLanguageId: string | null;
+    export let selectedLanguageId: number | null;
 
     const languagesToShow = allLanguages.filter((x) => existingTranslations.every((et) => et.languageId !== x.id));
 </script>


### PR DESCRIPTION
I modified `src/routes/resources/[resourceContentId]/TranslationSelector.svelte` to handle the value of the `languageid` as a number to take advantage of Svelte's type inference and help us avoid calling `toString()` and `parseInt()` when interacting with language Ids. This made sense as a language id is only ever a string when used in the value of the `option` html element and is never a string on the server.