### PR TITLE
Fix Fia step navigation alignment

### DIFF
--- a/src/lib/components/resources/Content.svelte
+++ b/src/lib/components/resources/Content.svelte
@@ -23,7 +23,7 @@
     export let wordCountsByStep: number[] | undefined = undefined;
     export let snapshotOrVersion: Snapshot | Version | undefined = undefined;
     export let selectedStepNumber: number | undefined;
-    export let isComparingToCurrent = false;
+    export let sidebarIsOpen = false;
     export let commentStores: CommentStores;
     export let machineTranslationStore: MachineTranslationStore;
 
@@ -37,7 +37,7 @@
     <Video content={videoContent} />
 {:else if resourceContent.mediaType === MediaTypeEnum.text}
     <Text
-        {isComparingToCurrent}
+        {sidebarIsOpen}
         bind:selectedStepNumber
         {snapshotOrVersion}
         {resourceContent}

--- a/src/lib/components/resources/content-components/Text.svelte
+++ b/src/lib/components/resources/content-components/Text.svelte
@@ -18,10 +18,11 @@
     export let wordCountsByStep: number[] | undefined;
     export let resourceContent: ResourceContent;
     export let snapshotOrVersion: Snapshot | Version | undefined;
-    export let isComparingToCurrent: boolean;
+    export let sidebarIsOpen: boolean;
     export let selectedStepNumber: number | undefined;
     export let commentStores: CommentStores;
     export let machineTranslationStore: MachineTranslationStore;
+    let isComparingToCurrent: boolean;
 
     onMount(() => (selectedStepNumber ||= 1));
 
@@ -92,6 +93,28 @@
                             <Icon data={arrowCircleRight} scale={1.5} />
                         </button>
                     {/if}
+                </div>
+            </div>
+        {/if}
+
+        {#if sidebarIsOpen && snapshotOrVersion !== undefined}
+            <div class="flex h-6 w-full flex-row items-center">
+                <div class="overflow-hidden text-ellipsis whitespace-nowrap text-lg">
+                    {snapshotOrVersion?.displayName}
+                </div>
+                <div class="grow"></div>
+                <div class="text-lg">
+                    <label class="label cursor-pointer py-0">
+                        <input
+                            type="checkbox"
+                            bind:checked={isComparingToCurrent}
+                            data-app-insights-event-name="resource-differences-toggled-{isComparingToCurrent
+                                ? 'off'
+                                : 'on'}"
+                            class="checkbox no-animation checkbox-sm me-2"
+                        />
+                        <span class="label-text text-xs">Differences</span>
+                    </label>
                 </div>
             </div>
         {/if}

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -91,7 +91,6 @@
     let isNewDraftStatus = false;
     let mediaType: MediaTypeEnum | undefined;
     let selectedStepNumber: number | undefined;
-    let isShowingDiffs = false;
     let openedSupplementalSideBar = OpenedSupplementalSideBar.None;
     let shouldTransition = false;
     let resourceContent: ResourceContent | undefined;
@@ -763,7 +762,7 @@
                         <Select
                             value={$sidebarContentStore.selected?.idForSelection ?? null}
                             onChange={sidebarContentStore.selectSnapshotOrVersion}
-                            class="select select-bordered select-sm"
+                            class="select select-bordered select-sm mb-4"
                             options={sidebarContentStore.allSnapshotAndPublishedVersionOptions.map((s) => ({
                                 value: s.value,
                                 label: s.label,
@@ -771,29 +770,10 @@
                         />
                         {#if $sidebarContentStore.isOpen}
                             {#if $sidebarContentStore.selected}
-                                <div class="my-4 flex h-6 w-full flex-row items-center">
-                                    <div class="overflow-hidden text-ellipsis whitespace-nowrap text-lg">
-                                        {$sidebarContentStore.selected.displayName}
-                                    </div>
-                                    <div class="grow"></div>
-                                    <div class="text-lg">
-                                        <label class="label cursor-pointer py-0">
-                                            <input
-                                                type="checkbox"
-                                                bind:checked={isShowingDiffs}
-                                                data-app-insights-event-name="resource-differences-toggled-{isShowingDiffs
-                                                    ? 'off'
-                                                    : 'on'}"
-                                                class="checkbox no-animation checkbox-sm me-2"
-                                            />
-                                            <span class="label-text text-xs">Differences</span>
-                                        </label>
-                                    </div>
-                                </div>
                                 <Content
                                     bind:selectedStepNumber
-                                    isComparingToCurrent={isShowingDiffs}
                                     {editableContentStore}
+                                    sidebarIsOpen={$sidebarContentStore.isOpen}
                                     snapshotOrVersion={$sidebarContentStore.selected}
                                     {resourceContent}
                                     {commentStores}


### PR DESCRIPTION
To align the Fia step controls, I had to move the display of the book and differences checkbox to the `Text` component. This helped clean up a small amount of logic that was unnecessary in the `+page.svelte` as well.