### PR TITLE
Remove tap preload

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -33,7 +33,7 @@
         %sveltekit.head%
     </head>
 
-    <body data-sveltekit-preload-data="tap" class="h-full">
+    <body class="h-full">
         <div id="svelte-loading-spinner">
             <span class="spinner"></span>
         </div>


### PR DESCRIPTION
The tap preload didn't differentiate between a regular click and a middle-click / ctrl+click (i.e. a click to open a new tab). So any time someone would do that, it would hit the API twice. This surely contributes to the performance issues with the database when someone quickly opens several items at once as new tabs.