### PR TITLE
fix some edge cases with machine translation ratings

### DIFF
--- a/src/lib/components/StarRating.svelte
+++ b/src/lib/components/StarRating.svelte
@@ -14,8 +14,7 @@
     }
 
     const onClick = (e: MouseEvent, newRating: number) => {
-        rating = newRating;
-        callback(e, rating);
+        callback(e, newRating);
     };
 </script>
 

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -930,7 +930,7 @@
                     Choose an Editor
                 {/if}
             </h3>
-            {#if $promptForMachineTranslationRating}
+            {#if $promptForMachineTranslationRating && currentUserIsAssigned}
                 <div class="mb-8 flex flex-col justify-start gap-4">
                     <div class="font-semibold text-error">Please rate the AI translation before reassigning.</div>
                     <div>


### PR DESCRIPTION
Instead of using Svelte reactivity to detect changes in the machine translation rating and PATCH it, directly PATCH based off of the input fields changing. Also adds a check to make sure the current user is assigned the content to rate since that came up in my testing.