### PR TITLE
fix tiptap popouts so they appear right next to content

### DIFF
--- a/src/lib/components/editorMarkPopouts/MarkPopout.svelte
+++ b/src/lib/components/editorMarkPopouts/MarkPopout.svelte
@@ -17,7 +17,7 @@
     {#key spanRect}
         <div
             bind:this={container}
-            class="absolute z-50 flex w-[300px] flex-col overflow-y-auto rounded-lg border-2 bg-white shadow"
+            class="fixed z-50 flex w-[300px] flex-col overflow-y-auto rounded-lg border-2 bg-white shadow"
             style="left: {spanRect.left -
                 (spanRect.left + 300 > windowInnerWidth ? 300 - spanRect.width : 0)}px; {heightAtBottom < 400
                 ? `top:${spanRect.top - parentHeight - 5}px; max-height:400px;`


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fead34d5-8e9c-42bb-ba52-f3edc43aa5b0)
