### PR TITLE
simplify API calls and promise-based loading

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,8 +26,9 @@ module.exports = {
         },
     ],
     rules: {
+        'require-await': 'error',
         'svelte/no-at-html-tags': 0,
-        'svelte/require-each-key': 1,
+        'svelte/require-each-key': 'error',
         eqeqeq: ['error', 'always'],
         'no-console': 'error',
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,20 +1,10 @@
 ﻿import type { HandleClientError } from '@sveltejs/kit';
 import { log } from '$lib/logger';
-import config from '$lib/config';
 
-// From the SvelteKit docs:
-//   This client-side hook runs when an unexpected error is thrown while navigating.
-//   If an unexpected error is thrown during loading or the following render, this function will be called with the error and the event.
-export const handleError = (async ({ error }: { error: unknown }) => {
+// This client-side hook runs when an error is thrown in a page.ts/layout.ts load function.
+// It only exists to log exceptions to App Insights and then pass along the error to `src/routes/+error.svelte`.
+export const handleError = (({ error }: { error: unknown }) => {
     log.exception(error);
 
-    if (config.PUBLIC_ENV === 'qa' || config.PUBLIC_ENV === 'dev' || config.PUBLIC_ENV === 'local') {
-        return {
-            message: (error as Error).message,
-        };
-    } else {
-        return {
-            message: 'Unexpected error',
-        };
-    }
+    return error as Error;
 }) satisfies HandleClientError;

--- a/src/lib/charts/TotalResourcesAreaChart.svelte
+++ b/src/lib/charts/TotalResourcesAreaChart.svelte
@@ -129,7 +129,7 @@
         },
     };
 
-    onMount(async () => {
+    onMount(() => {
         let canvas = document?.getElementById('totalResourcesAreaChart') as HTMLCanvasElement | undefined;
         let canvasContext = canvas?.getContext('2d');
         if (canvasContext) {

--- a/src/lib/charts/TranslatedResourcesBarChart.svelte
+++ b/src/lib/charts/TranslatedResourcesBarChart.svelte
@@ -132,7 +132,7 @@
         },
     };
 
-    onMount(async () => {
+    onMount(() => {
         let canvas = document?.getElementById('areaChartCanvas') as HTMLCanvasElement | undefined;
         let canvasContext = canvas?.getContext('2d');
         if (canvasContext) {

--- a/src/lib/components/ErrorMessage.svelte
+++ b/src/lib/components/ErrorMessage.svelte
@@ -6,13 +6,27 @@
         FetchError,
         TokenMissingError,
     } from '$lib/utils/http-errors';
-    import { onMount } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
     import { goto } from '$app/navigation';
-    import { page } from '$app/stores';
     import CenteredSpinnerFullScreen from './CenteredSpinnerFullScreen.svelte';
+    import errorGotoPath from '$lib/stores/error-goto-path';
+
+    /**
+     * ErrorMessage component handles various error states and provides appropriate user feedback.
+     * It accepts an uncastError prop which can be various error types (Error, FetchError, ApiError, etc.).
+     * Based on the error type, it either:
+     * - Redirects to a specified path (for 404 errors)
+     * - Shows a rate limit message with refresh button (for 429 errors)
+     * - Displays a generic error message with navigation button
+     *
+     * It uses the `errorGotoPath` to determine where to redirect users after certain error states are handled,
+     * defaulting to the home route when no path is specified.
+     *
+     * The primary usage is the generic `src/routes/+error.svelte` but it can also be used in `{#await}{:then}{:catch}`
+     * Svelte blocks to easily handle errors in a specific part of the page.
+     */
 
     export let uncastError;
-    export let gotoPath = '/';
 
     let buttonText = '';
     let errorMessage = '';
@@ -26,21 +40,27 @@
             location.reload();
         }
 
-        goto(gotoPath);
+        goto($errorGotoPath ?? '/');
     }
 
     onMount(() => {
-        if (isApiErrorWithStatus(error, 404) || $page.status === 404) {
-            goto(gotoPath);
+        if (isApiErrorWithStatus(error, 404)) {
+            goto($errorGotoPath ?? '');
         } else if (isApiErrorWithStatus(error, 429)) {
             buttonText = 'Refresh';
             errorMessage = 'Rate limit exceeded.';
             didNotRedirect = true;
         } else {
             errorMessage = 'An error occurred';
-            buttonText = gotoPath === '/' ? 'Go Home' : `Go To ${gotoPath.replace('/', '')}`;
+            buttonText = $errorGotoPath === null ? 'Go Home' : `Go To ${$errorGotoPath.replace('/', '')}`;
             didNotRedirect = true;
         }
+    });
+
+    onDestroy(() => {
+        // when navigating away from a page with an error, reset `errorGotoPath`
+        // it will then be ready to be set by the next page's `load` function if necessary
+        errorGotoPath.set(null);
     });
 </script>
 

--- a/src/lib/components/MachineTranslationRating.svelte
+++ b/src/lib/components/MachineTranslationRating.svelte
@@ -39,7 +39,7 @@
     $: $promptForRating && (translationsMissingRatings = null);
     $: syncMachineTranslationFromStore($store);
 
-    async function updateMachineTranslation() {
+    function updateMachineTranslation() {
         if (showingInPrompt) {
             translationsMissingRatings ||= [...$store.values()].filter((mt) => !mt.userRating);
             machineTranslationStore.debounce(async () => {
@@ -87,7 +87,7 @@
         } as MachineTranslation;
     }
 
-    const onRating = async (e: MouseEvent, newRating: number) => {
+    const onRating = (e: MouseEvent, newRating: number) => {
         e.stopPropagation();
 
         if (machineTranslation.userRating !== newRating) {

--- a/src/lib/components/comments/CommentThread.svelte
+++ b/src/lib/components/comments/CommentThread.svelte
@@ -35,7 +35,7 @@
         scrollParentDivToBottom();
     };
 
-    const onEditClick = async (comment: Comment) => {
+    const onEditClick = (comment: Comment) => {
         isCommenting = true;
         editingCommentId = comment.id;
         previousCommentValue = comment.comment;
@@ -144,7 +144,7 @@
         }
     };
 
-    const onEditCommentClick = async (e: MouseEvent, comment: Comment) => {
+    const onEditCommentClick = async (_: MouseEvent, comment: Comment) => {
         isSendingComment = true;
         try {
             await patchToApi(`/comments/${comment.id}`, {

--- a/src/lib/components/comments/InlineComment.svelte
+++ b/src/lib/components/comments/InlineComment.svelte
@@ -19,7 +19,7 @@
         window.onInlineCommentClick = onInlineCommentClick;
     });
 
-    async function onInlineCommentClick(selectedThreadId: number, spanId: string) {
+    function onInlineCommentClick(selectedThreadId: number, spanId: string) {
         if (isCommenting) return;
 
         markSpan = document.getElementById(spanId);

--- a/src/lib/components/editor/TiptapDiffRenderer.svelte
+++ b/src/lib/components/editor/TiptapDiffRenderer.svelte
@@ -50,6 +50,7 @@
         async (
             currentTiptapJsonForDiffing: TiptapContentItem | undefined,
             baseHtmlWithTextDirection: string | undefined
+            // eslint-disable-next-line
         ) => {
             if (
                 currentTiptapJsonForDiffing &&
@@ -115,7 +116,7 @@
         }
     };
 
-    onMount(async () => {
+    onMount(() => {
         if (scrollSyncElement) {
             scrollSyncElement.scrollTop = 0;
         }

--- a/src/lib/components/editor/TiptapRenderer.svelte
+++ b/src/lib/components/editor/TiptapRenderer.svelte
@@ -62,7 +62,7 @@
         editor?.setEditable(canEdit);
     }
 
-    onMount(async () => {
+    onMount(() => {
         if (scrollSyncElement) {
             scrollSyncElement.scrollTop = 0;
         }

--- a/src/lib/components/projects/ProjectTable.svelte
+++ b/src/lib/components/projects/ProjectTable.svelte
@@ -13,7 +13,7 @@
     import { createProjectListSorter, SortName } from './project-table-sorter';
 
     export let isShowing: boolean;
-    export let languages: Language[] = [];
+    export let languages: Language[];
     export let companies: Company[];
     export let currentTab: ProjectStatusTab;
     export let activeProjects: ProjectListResponse[];

--- a/src/lib/components/resources/menus/CurrentTranslations.svelte
+++ b/src/lib/components/resources/menus/CurrentTranslations.svelte
@@ -12,7 +12,7 @@
     export let englishTranslation: ContentTranslation | undefined;
     export let canCreateTranslation: boolean;
     export let openModal: () => void;
-    export let currentResourceId: string;
+    export let currentResourceId: number;
     export let project: Project | null;
 
     $: numberOfTranslations = translations.length;
@@ -27,9 +27,9 @@
         'languageName'
     )!;
 
-    const currentResource = mappedTranslations.find((x) => x.contentId === parseInt(currentResourceId));
+    const currentResource = mappedTranslations.find((x) => x.contentId === currentResourceId);
 
-    const filteredMappedTranslations = mappedTranslations.filter((x) => x.contentId !== parseInt(currentResourceId));
+    const filteredMappedTranslations = mappedTranslations.filter((x) => x.contentId !== currentResourceId);
 </script>
 
 <div class="dropdown ms-2">

--- a/src/lib/stores/error-goto-path.ts
+++ b/src/lib/stores/error-goto-path.ts
@@ -1,0 +1,17 @@
+import { writable } from 'svelte/store';
+
+/**
+ * A writable store that manages error navigation paths for pages.
+ * Used within `+page.ts#load` functions to configure redirect paths for 404 errors
+ * and provide a "Go to ..." button for other error types.
+ *
+ * @example
+ * // In +page.ts
+ * export const load = () => {
+ *   errorGotoPath.set('/dashboard');
+ *   // ... rest of load logic
+ * }
+ */
+const errorGotoPath = writable<string | null>(null);
+
+export default errorGotoPath;

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -1,10 +1,9 @@
-// eslint-disable-next-line
-export function debounce<T extends (...args: any[]) => Promise<void>>(
+export function debounce<T extends (...args: Parameters<T>) => Promise<void>>(
     func: T,
     delay: number
 ): (...args: Parameters<T>) => Promise<void> {
     let timeoutId: NodeJS.Timeout | null = null;
-    return async (...args: Parameters<T>) => {
+    return (...args: Parameters<T>) => {
         if (timeoutId !== null) {
             clearTimeout(timeoutId);
         }

--- a/src/routes/(dashboard)/CommunityReviewerDashboard.svelte
+++ b/src/routes/(dashboard)/CommunityReviewerDashboard.svelte
@@ -8,13 +8,7 @@
     import Table from '$lib/components/Table.svelte';
     import { myHistoryColumns, resourcesThatNeedTranslationColumns } from './community-reviewer-dashboard-columns';
     import TableCell from '$lib/components/TableCell.svelte';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
-    import ErrorMessage from '$lib/components/ErrorMessage.svelte';
-    import type {
-        ResourceAssignedToSelf,
-        ResourceThatNeedsTranslation,
-        ResourceThatNeedsTranslationResponse,
-    } from './+page';
+    import type { ResourceThatNeedsTranslation, ResourceThatNeedsTranslationResponse } from './+page';
     import { getFromApi } from '$lib/utils/http-service';
     import Select from '$lib/components/Select.svelte';
     import { _ as translate } from 'svelte-i18n';
@@ -26,6 +20,11 @@
     const sortMyHistoryData = createEditorDashboardMyHistorySorter();
 
     export let data: PageData;
+
+    $: bibleBooks = data.communityReviewerDashboard!.bibleBooks;
+    $: myAssignedContents = data.communityReviewerDashboard!.assignedResourceContent;
+    $: myHistoryContents = data.communityReviewerDashboard!.assignedResourceHistoryContent;
+    $: currentlyReviewingItem = myAssignedContents[0];
 
     enum Tab {
         resources = 'resources',
@@ -48,16 +47,12 @@
     );
 
     let myHistorySearchQuery = '';
-    let myHistoryContents: ResourceAssignedToSelfHistory[] = [];
-    // eslint-disable-next-line
-    let table: Table<any> | null;
+    let table: Table<ResourceThatNeedsTranslation> | Table<ResourceAssignedToSelfHistory> | undefined;
     $: $searchParams.sort && table?.resetScroll();
 
-    let currentlyReviewingItem: ResourceAssignedToSelf | null = null;
     let resourcesThatNeedTranslation: ResourceThatNeedsTranslation[] | null = null;
     let resourcesThatNeedTranslationParams: Param[] = [];
     let resourcesSearchQuery = '';
-    let bibleBooks: BibleBook[] | null = null;
     let parentResourceId = 0;
     let bookCode = '';
     let chapterRange = '';
@@ -119,147 +114,129 @@
         );
     }
 
-    const loadContents = async () => {
-        let myAssignedContents: ResourceAssignedToSelf[];
-        [bibleBooks, myAssignedContents, myHistoryContents] = await Promise.all([
-            data.communityReviewerDashboard!.bibleBooks.promise,
-            data.communityReviewerDashboard!.assignedResourceContent.promise,
-            data.communityReviewerDashboard!.assignedResourceHistoryContent.promise,
-        ]);
-        currentlyReviewingItem = myAssignedContents[0] ?? null;
-    };
-
-    function calculateMaxChapter(bibleBooks: BibleBook[] | null) {
-        return bibleBooks?.find((b) => b.code === bookCode)?.totalChapters ?? 0;
+    function calculateMaxChapter(bibleBooks: BibleBook[]) {
+        return bibleBooks.find((b) => b.code === bookCode)?.totalChapters ?? 0;
     }
 </script>
 
-{#await loadContents()}
-    <CenteredSpinnerFullScreen />
-{:then _}
-    <div class="flex h-full flex-col space-y-4 overflow-y-hidden px-4">
-        <h1 class="pt-4 text-3xl">Dashboard</h1>
-        {#if currentlyReviewingItem}
-            <div class="text-lg">
-                <span>You are currently reviewing this item:</span>
-                <a class="text-lg font-bold text-primary underline" href="/resources/{currentlyReviewingItem.id}"
-                    >{currentlyReviewingItem.englishLabel}</a
-                >
-            </div>
-        {/if}
-        <div class="flex flex-shrink-0 flex-row items-center">
-            <div role="tablist" class="tabs tabs-bordered w-fit">
-                <button
-                    on:click={() => switchTabs(Tab.resources)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.resources && 'tab-active'}">Resources</button
-                >
-                <button
-                    on:click={() => switchTabs(Tab.myHistory)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.myHistory && 'tab-active'}"
-                    >My History ({myHistoryContents.length})</button
-                >
-            </div>
+<div class="flex h-full flex-col space-y-4 overflow-y-hidden px-4">
+    <h1 class="pt-4 text-3xl">Dashboard</h1>
+    {#if currentlyReviewingItem}
+        <div class="text-lg">
+            <span>You are currently reviewing this item:</span>
+            <a class="text-lg font-bold text-primary underline" href="/resources/{currentlyReviewingItem.id}"
+                >{currentlyReviewingItem.englishLabel}</a
+            >
         </div>
-        <div class="flex flex-shrink-0 gap-4 overflow-x-auto">
-            {#if $searchParams.tab === Tab.resources}
-                <input
-                    class="input input-bordered max-w-xs focus:outline-none"
-                    bind:value={resourcesSearchQuery}
-                    use:enterKeyHandler={fetchResources}
-                    placeholder="Search"
-                />
-            {:else if $searchParams.tab === Tab.myHistory}
-                <input
-                    class="input input-bordered max-w-xs focus:outline-none"
-                    bind:value={myHistorySearchQuery}
-                    placeholder="Search"
-                />
-            {/if}
-            {#if $searchParams.tab === Tab.resources}
-                <Select
-                    appInsightsEventName="resources-resources-filter-selection"
-                    bind:value={parentResourceId}
-                    isNumber={true}
-                    class="select select-bordered min-w-[10rem]"
-                    options={[
-                        { value: 0, label: $translate('page.resources.dropdowns.allResources.value') },
-                        ...data.parentResources.map((t) => ({ value: t.id, label: t.displayName })),
-                    ]}
-                />
-                <Select
-                    appInsightsEventName="resources-book-filter-selection"
-                    class="select select-bordered min-w-[9rem]"
-                    options={[
-                        { value: '', label: 'Select Book' },
-                        ...(bibleBooks || []).map((b) => ({ value: b.code, label: b.localizedName })),
-                    ]}
-                    onChange={() => (chapterRange = '')}
-                    bind:value={bookCode}
-                />
-                <input
-                    disabled={!bookCode}
-                    bind:value={chapterRange}
-                    use:enterKeyHandler={fetchResources}
-                    class="input input-bordered input-md w-[11rem] focus:outline-none"
-                    placeholder="Chapter (e.g. 2, 1-5)"
-                />
-                <button class="btn btn-primary" disabled={!canApplyFilters} on:click={() => fetchResources()}
-                    >Apply</button
-                >
-            {/if}
+    {/if}
+    <div class="flex flex-shrink-0 flex-row items-center">
+        <div role="tablist" class="tabs tabs-bordered w-fit">
+            <button
+                on:click={() => switchTabs(Tab.resources)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.resources && 'tab-active'}">Resources</button
+            >
+            <button
+                on:click={() => switchTabs(Tab.myHistory)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.myHistory && 'tab-active'}"
+                >My History ({myHistoryContents.length})</button
+            >
         </div>
+    </div>
+    <div class="flex flex-shrink-0 gap-4 overflow-x-auto">
         {#if $searchParams.tab === Tab.resources}
-            <Table
-                class="!mb-2"
-                columns={resourcesThatNeedTranslationColumns}
-                items={resourcesThatNeedTranslation ?? []}
-                idColumn="id"
-                itemUrlPrefix="/resources/"
-                noItemsText={resourcesThatNeedTranslation
-                    ? 'No results'
-                    : 'Search or filter to see resource items that need translations'}
-                {isLoading}
-                bind:currentPage
-                bind:itemsPerPage
-                {totalItems}
-                let:item
-                let:href
-                let:itemKey
-            >
-                {#if href !== undefined && itemKey}
-                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                {:else if itemKey}
-                    <TableCell>{item[itemKey] ?? ''}</TableCell>
-                {/if}
-            </Table>
+            <input
+                class="input input-bordered max-w-xs focus:outline-none"
+                bind:value={resourcesSearchQuery}
+                use:enterKeyHandler={fetchResources}
+                placeholder="Search"
+            />
         {:else if $searchParams.tab === Tab.myHistory}
-            <Table
-                bind:this={table}
-                class="!mb-2"
-                columns={myHistoryColumns}
-                items={filterAndSortMyHistoryData(myHistoryContents, $searchParams.sort, myHistorySearchQuery)}
-                idColumn="id"
-                itemUrlPrefix="/resources/"
-                bind:searchParams={$searchParams}
-                noItemsText="No history items"
-                let:item
-                let:href
-                let:itemKey
-            >
-                {#if itemKey === 'lastActionTime' && item[itemKey] !== null}
-                    <LinkedTableCell {href}
-                        >{utcDateTimeStringToDateTime(item[itemKey]).toLocaleDateString()}</LinkedTableCell
-                    >
-                {:else if href !== undefined && itemKey}
-                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                {:else if itemKey}
-                    <TableCell>{item[itemKey] ?? ''}</TableCell>
-                {/if}
-            </Table>
+            <input
+                class="input input-bordered max-w-xs focus:outline-none"
+                bind:value={myHistorySearchQuery}
+                placeholder="Search"
+            />
+        {/if}
+        {#if $searchParams.tab === Tab.resources}
+            <Select
+                appInsightsEventName="resources-resources-filter-selection"
+                bind:value={parentResourceId}
+                isNumber={true}
+                class="select select-bordered min-w-[10rem]"
+                options={[
+                    { value: 0, label: $translate('page.resources.dropdowns.allResources.value') },
+                    ...data.parentResources.map((t) => ({ value: t.id, label: t.displayName })),
+                ]}
+            />
+            <Select
+                appInsightsEventName="resources-book-filter-selection"
+                class="select select-bordered min-w-[9rem]"
+                options={[
+                    { value: '', label: 'Select Book' },
+                    ...(bibleBooks || []).map((b) => ({ value: b.code, label: b.localizedName })),
+                ]}
+                onChange={() => (chapterRange = '')}
+                bind:value={bookCode}
+            />
+            <input
+                disabled={!bookCode}
+                bind:value={chapterRange}
+                use:enterKeyHandler={fetchResources}
+                class="input input-bordered input-md w-[11rem] focus:outline-none"
+                placeholder="Chapter (e.g. 2, 1-5)"
+            />
+            <button class="btn btn-primary" disabled={!canApplyFilters} on:click={() => fetchResources()}>Apply</button>
         {/if}
     </div>
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+    {#if $searchParams.tab === Tab.resources}
+        <Table
+            class="!mb-2"
+            columns={resourcesThatNeedTranslationColumns}
+            items={resourcesThatNeedTranslation ?? []}
+            idColumn="id"
+            itemUrlPrefix="/resources/"
+            noItemsText={resourcesThatNeedTranslation
+                ? 'No results'
+                : 'Search or filter to see resource items that need translations'}
+            {isLoading}
+            bind:currentPage
+            bind:itemsPerPage
+            {totalItems}
+            let:item
+            let:href
+            let:itemKey
+        >
+            {#if href !== undefined && itemKey}
+                <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+            {:else if itemKey}
+                <TableCell>{item[itemKey] ?? ''}</TableCell>
+            {/if}
+        </Table>
+    {:else if $searchParams.tab === Tab.myHistory}
+        <Table
+            bind:this={table}
+            class="!mb-2"
+            columns={myHistoryColumns}
+            items={filterAndSortMyHistoryData(myHistoryContents, $searchParams.sort, myHistorySearchQuery)}
+            idColumn="id"
+            itemUrlPrefix="/resources/"
+            bind:searchParams={$searchParams}
+            noItemsText="No history items"
+            let:item
+            let:href
+            let:itemKey
+        >
+            {#if itemKey === 'lastActionTime' && item[itemKey] !== null}
+                <LinkedTableCell {href}
+                    >{utcDateTimeStringToDateTime(item[itemKey]).toLocaleDateString()}</LinkedTableCell
+                >
+            {:else if href !== undefined && itemKey}
+                <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+            {:else if itemKey}
+                <TableCell>{item[itemKey] ?? ''}</TableCell>
+            {/if}
+        </Table>
+    {/if}
+</div>

--- a/src/routes/(dashboard)/EditorDashboard.svelte
+++ b/src/routes/(dashboard)/EditorDashboard.svelte
@@ -13,8 +13,6 @@
     import { myHistoryColumns, myWorkColumns } from './editor-dashboard-columns';
     import TableCell from '$lib/components/TableCell.svelte';
     import { download } from '$lib/utils/csv-download-handler';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
-    import ErrorMessage from '$lib/components/ErrorMessage.svelte';
     import Select from '$lib/components/Select.svelte';
     import { filterBoolean } from '$lib/utils/array';
 
@@ -22,6 +20,9 @@
     const sortMyHistoryData = createEditorDashboardMyHistorySorter();
 
     export let data: PageData;
+
+    $: myWorkContents = data.editorDashboard!.assignedResourceContent;
+    $: myHistoryContents = data.editorDashboard!.assignedResourceHistoryContent;
 
     enum Tab {
         myWork = 'my-work',
@@ -75,132 +76,115 @@
     };
 
     let search = '';
-    let myWorkContents: ResourceAssignedToSelf[] = [];
     let visibleMyWorkContents: ResourceAssignedToSelf[] = [];
-    let myHistoryContents: ResourceAssignedToSelfHistory[] = [];
     let visibleMyHistoryContents: ResourceAssignedToSelfHistory[] = [];
-    // eslint-disable-next-line
-    let table: Table<any> | null;
+    let table: Table<ResourceAssignedToSelfHistory> | Table<ResourceAssignedToSelf> | undefined;
     $: $searchParams.sort && table?.resetScroll();
     $: setTabContents($searchParams.tab, search, $searchParams.project);
-
-    const loadContents = async () => {
-        [myWorkContents, myHistoryContents] = await Promise.all([
-            data.editorDashboard!.assignedResourceContent.promise,
-            data.editorDashboard!.assignedResourceHistoryContent.promise,
-        ]);
-    };
 
     function projectNamesForContents(contents: ResourceAssignedToSelf[]) {
         return Array.from(new Set(filterBoolean(contents.map((c) => c.projectName)))).sort();
     }
 </script>
 
-{#await loadContents()}
-    <CenteredSpinnerFullScreen />
-{:then _}
-    <div class="flex flex-col overflow-y-hidden px-4">
-        <h1 class="pt-4 text-3xl">Dashboard</h1>
-        <div class="flex flex-row items-center pt-4">
-            <div role="tablist" class="tabs tabs-bordered w-fit">
-                <button
-                    on:click={() => switchTabs(Tab.myWork)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.myWork && 'tab-active'}"
-                    >My Work ({myWorkContents.length})</button
-                >
-                <button
-                    on:click={() => switchTabs(Tab.myHistory)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.myHistory && 'tab-active'}"
-                    >My History ({myHistoryContents.length})</button
-                >
-            </div>
+<div class="flex flex-col overflow-y-hidden px-4">
+    <h1 class="pt-4 text-3xl">Dashboard</h1>
+    <div class="flex flex-row items-center pt-4">
+        <div role="tablist" class="tabs tabs-bordered w-fit">
+            <button
+                on:click={() => switchTabs(Tab.myWork)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.myWork && 'tab-active'}">My Work ({myWorkContents.length})</button
+            >
+            <button
+                on:click={() => switchTabs(Tab.myHistory)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.myHistory && 'tab-active'}"
+                >My History ({myHistoryContents.length})</button
+            >
         </div>
-        <div class="mt-4 flex gap-4">
-            <input class="input input-bordered max-w-xs focus:outline-none" bind:value={search} placeholder="Search" />
-            {#if $searchParams.tab === Tab.myWork}
-                <Select
-                    class="select select-bordered max-w-[14rem] flex-grow"
-                    bind:value={$searchParams.project}
-                    options={[
-                        { value: '', label: 'Project' },
-                        ...projectNamesForContents(myWorkContents).map((p) => ({ value: p, label: p })),
-                    ]}
-                />
-            {/if}
-            {#if $searchParams.tab === Tab.myWork}
-                <div class="my-1 ml-auto flex flex-col items-end justify-center">
-                    <div class="text-sm text-gray-500">Total Items: {visibleMyWorkContents.length}</div>
-                    <div class="text-sm text-gray-500">
-                        Total Source Words: {visibleMyWorkContents
-                            .reduce((sum, x) => sum + (x?.wordCount ?? 0), 0)
-                            .toLocaleString()}
-                    </div>
-                </div>
-            {/if}
-            {#if $searchParams.tab === Tab.myHistory}
-                <button
-                    data-app-insights-event-name="editor-dashboard-download-my-history-csv-click"
-                    class="btn btn-primary"
-                    on:click={downloadMyHistoryCsv}>Download Word Counts</button
-                >
-            {/if}
-        </div>
+    </div>
+    <div class="mt-4 flex gap-4">
+        <input class="input input-bordered max-w-xs focus:outline-none" bind:value={search} placeholder="Search" />
         {#if $searchParams.tab === Tab.myWork}
-            <Table
-                bind:this={table}
-                class="my-4"
-                columns={myWorkColumns}
-                items={sortMyWorkData(visibleMyWorkContents, $searchParams.sort)}
-                idColumn="id"
-                itemUrlPrefix="/resources/"
-                bind:searchParams={$searchParams}
-                noItemsText="Your work is all done!"
-                searchable={true}
-                searchText={search}
-                noItemsAfterSearchText="No items found"
-                let:item
-                let:href
-                let:itemKey
+            <Select
+                class="select select-bordered max-w-[14rem] flex-grow"
+                bind:value={$searchParams.project}
+                options={[
+                    { value: '', label: 'Project' },
+                    ...projectNamesForContents(myWorkContents).map((p) => ({ value: p, label: p })),
+                ]}
+            />
+        {/if}
+        {#if $searchParams.tab === Tab.myWork}
+            <div class="my-1 ml-auto flex flex-col items-end justify-center">
+                <div class="text-sm text-gray-500">Total Items: {visibleMyWorkContents.length}</div>
+                <div class="text-sm text-gray-500">
+                    Total Source Words: {visibleMyWorkContents
+                        .reduce((sum, x) => sum + (x?.wordCount ?? 0), 0)
+                        .toLocaleString()}
+                </div>
+            </div>
+        {/if}
+        {#if $searchParams.tab === Tab.myHistory}
+            <button
+                data-app-insights-event-name="editor-dashboard-download-my-history-csv-click"
+                class="btn btn-primary"
+                on:click={downloadMyHistoryCsv}>Download Word Counts</button
             >
-                {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
-                    <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
-                {:else if href !== undefined && itemKey}
-                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                {:else if itemKey}
-                    <TableCell>{item[itemKey] ?? ''}</TableCell>
-                {/if}
-            </Table>
-        {:else if $searchParams.tab === Tab.myHistory}
-            <Table
-                bind:this={table}
-                class="my-4"
-                columns={myHistoryColumns}
-                items={sortMyHistoryData(visibleMyHistoryContents, $searchParams.sort)}
-                idColumn="id"
-                itemUrlPrefix="/resources/"
-                bind:searchParams={$searchParams}
-                noItemsText="No history items"
-                searchable={true}
-                searchText={search}
-                noItemsAfterSearchText="No items found"
-                let:item
-                let:href
-                let:itemKey
-            >
-                {#if itemKey === 'lastActionTime' && item[itemKey] !== null}
-                    <LinkedTableCell {href}
-                        >{utcDateTimeStringToDateTime(item[itemKey]).toLocaleDateString()}</LinkedTableCell
-                    >
-                {:else if href !== undefined && itemKey}
-                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                {:else if itemKey}
-                    <TableCell>{item[itemKey] ?? ''}</TableCell>
-                {/if}
-            </Table>
         {/if}
     </div>
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+    {#if $searchParams.tab === Tab.myWork}
+        <Table
+            bind:this={table}
+            class="my-4"
+            columns={myWorkColumns}
+            items={sortMyWorkData(visibleMyWorkContents, $searchParams.sort)}
+            idColumn="id"
+            itemUrlPrefix="/resources/"
+            bind:searchParams={$searchParams}
+            noItemsText="Your work is all done!"
+            searchable={true}
+            searchText={search}
+            noItemsAfterSearchText="No items found"
+            let:item
+            let:href
+            let:itemKey
+        >
+            {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
+                <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
+            {:else if href !== undefined && itemKey}
+                <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+            {:else if itemKey}
+                <TableCell>{item[itemKey] ?? ''}</TableCell>
+            {/if}
+        </Table>
+    {:else if $searchParams.tab === Tab.myHistory}
+        <Table
+            bind:this={table}
+            class="my-4"
+            columns={myHistoryColumns}
+            items={sortMyHistoryData(visibleMyHistoryContents, $searchParams.sort)}
+            idColumn="id"
+            itemUrlPrefix="/resources/"
+            bind:searchParams={$searchParams}
+            noItemsText="No history items"
+            searchable={true}
+            searchText={search}
+            noItemsAfterSearchText="No items found"
+            let:item
+            let:href
+            let:itemKey
+        >
+            {#if itemKey === 'lastActionTime' && item[itemKey] !== null}
+                <LinkedTableCell {href}
+                    >{utcDateTimeStringToDateTime(item[itemKey]).toLocaleDateString()}</LinkedTableCell
+                >
+            {:else if href !== undefined && itemKey}
+                <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+            {:else if itemKey}
+                <TableCell>{item[itemKey] ?? ''}</TableCell>
+            {/if}
+        </Table>
+    {/if}
+</div>

--- a/src/routes/(dashboard)/ManagerDashboard.svelte
+++ b/src/routes/(dashboard)/ManagerDashboard.svelte
@@ -22,10 +22,36 @@
         manageContentsColumns,
         userWordCountColumns,
     } from './manager-dashboard-columns';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
-    import ErrorMessage from '$lib/components/ErrorMessage.svelte';
 
     export let data: PageData;
+
+    $: manageContents = data.managerDashboard!.manageResourceContent;
+    $: toAssignContents = data.managerDashboard!.toAssignContent;
+    $: myWorkContents = data.managerDashboard!.assignedResourceContent;
+    $: userWordCounts = data.managerDashboard!.assignedUsersWordCount;
+
+    $: myWorkProjectNames = Array.from(new Set(filterBoolean(myWorkContents.map((c) => c.projectName)))).sort();
+    $: myWorkLastAssignedUsers = sortByKey(
+        'name',
+        filterDuplicatesByKey('id', filterBoolean(myWorkContents.map((c) => c.lastAssignedUser)))
+    );
+
+    $: toAssignProjectNames = Array.from(new Set(filterBoolean(toAssignContents.map((c) => c.projectName)))).sort();
+
+    $: manageProjectNames = Array.from(new Set(filterBoolean(manageContents.map((c) => c.projectName)))).sort();
+    $: manageLastAssignedUsers = sortByKey(
+        'name',
+        filterDuplicatesByKey('id', filterBoolean(manageContents.map((c) => c.lastAssignedUser)))
+    );
+
+    $: maybeResetSearchParams(
+        toAssignProjectNames,
+        manageProjectNames,
+        myWorkProjectNames,
+        manageLastAssignedUsers,
+        myWorkLastAssignedUsers
+    );
+
     let search = '';
 
     enum Tab {
@@ -63,26 +89,16 @@
 
     $: !isErrorModalOpen && (customErrorMessage = null);
 
-    let myWorkProjectNames: string[] = [];
-    let myWorkLastAssignedUsers: BasicUser[] = [];
-    let toAssignProjectNames: string[] = [];
-    let manageProjectNames: string[] = [];
-    let manageLastAssignedUsers: BasicUser[] = [];
     let currentProjectNames: string[] = [];
     let currentLastAssignedUsers: BasicUser[] = [];
-    let myWorkContents: ResourceAssignedToSelf[] = [];
     let currentMyWorkContents: ResourceAssignedToSelf[] = [];
     let selectedMyWorkContents: ResourceAssignedToSelf[] = [];
 
-    let toAssignContents: ResourceAssignedToSelf[] = [];
     let currentToAssignContents: ResourceAssignedToSelf[] = [];
     let selectedToAssignContents: ResourceAssignedToSelf[] = [];
 
-    let manageContents: ResourceAssignedToOwnCompany[] = [];
     let currentManageContents: ResourceAssignedToOwnCompany[] = [];
     let selectedManageContents: ResourceAssignedToOwnCompany[] = [];
-
-    let userWordCounts: UserWordCount[] = [];
 
     const setTabContents = (
         tab: string,
@@ -132,33 +148,13 @@
             ].includes(x.statusValue)
     );
 
-    const loadContents = async () => {
-        const manageContentsPromise = data.managerDashboard!.manageResourceContent.promise;
-        const toAssignContentsPromise = data.managerDashboard!.toAssignContent.promise;
-        const assignedContentsPromise = data.managerDashboard!.assignedResourceContent.promise;
-        const userWordCountsPromise = data.managerDashboard!.assignedUsersWordCount.promise;
-
-        [myWorkContents, toAssignContents, manageContents, userWordCounts] = await Promise.all([
-            assignedContentsPromise,
-            toAssignContentsPromise,
-            manageContentsPromise,
-            userWordCountsPromise,
-        ]);
-
-        myWorkProjectNames = Array.from(new Set(filterBoolean(myWorkContents.map((c) => c.projectName)))).sort();
-        myWorkLastAssignedUsers = sortByKey(
-            'name',
-            filterDuplicatesByKey('id', filterBoolean(myWorkContents.map((c) => c.lastAssignedUser)))
-        );
-
-        toAssignProjectNames = Array.from(new Set(filterBoolean(toAssignContents.map((c) => c.projectName)))).sort();
-
-        manageProjectNames = Array.from(new Set(filterBoolean(manageContents.map((c) => c.projectName)))).sort();
-        manageLastAssignedUsers = sortByKey(
-            'name',
-            filterDuplicatesByKey('id', filterBoolean(manageContents.map((c) => c.lastAssignedUser)))
-        );
-
+    function maybeResetSearchParams(
+        toAssignProjectNames: string[],
+        manageProjectNames: string[],
+        myWorkProjectNames: string[],
+        manageLastAssignedUsers: BasicUser[],
+        myWorkLastAssignedUsers: BasicUser[]
+    ) {
         // Handle situation where project is set in the searchParams but is no longer valid. E.g. saved bookmark
         // or forced refresh after assign that removed all of them.
         if (
@@ -177,7 +173,7 @@
         ) {
             $searchParams.lastAssignedId = 0;
         }
-    };
+    }
 
     const switchProjectAndLastAssignedNames = (tab: string) => {
         if (tab === Tab.myWork) {
@@ -262,10 +258,8 @@
         }
     }
 
-    // eslint-disable-next-line
-    let table: Table<any> | null;
-    // eslint-disable-next-line
-    let userWordCountTable: Table<any> | null;
+    let table: Table<ResourceAssignedToSelf> | Table<ResourceAssignedToOwnCompany> | undefined;
+    let userWordCountTable: Table<UserWordCount> | undefined;
 
     $: userWordCountParams.sort && userWordCountTable?.resetScroll();
     $: $searchParams.sort && $searchParams.tab && table?.resetScroll();
@@ -294,106 +288,131 @@
     $: switchProjectAndLastAssignedNames($searchParams.tab);
 </script>
 
-{#await loadContents()}
-    <CenteredSpinnerFullScreen />
-{:then _}
-    <div class="flex flex-col overflow-y-hidden px-4">
-        <h1 class="pt-4 text-3xl">Dashboard</h1>
-        <div class="flex flex-row items-center pt-4">
-            <div role="tablist" class="tabs tabs-bordered w-fit">
-                <button
-                    on:click={() => switchTabs(Tab.myWork)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.myWork && 'tab-active'}"
-                    >My Work ({myWorkContents.length})</button
-                >
-                <button
-                    on:click={() => switchTabs(Tab.toAssign)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.toAssign && 'tab-active'}"
-                    >To Assign ({toAssignContents.length})</button
-                >
-                <button
-                    on:click={() => switchTabs(Tab.manage)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.manage && 'tab-active'}"
-                    >Manage ({manageContents.length})</button
-                >
-            </div>
+<div class="flex flex-col overflow-y-hidden px-4">
+    <h1 class="pt-4 text-3xl">Dashboard</h1>
+    <div class="flex flex-row items-center pt-4">
+        <div role="tablist" class="tabs tabs-bordered w-fit">
+            <button
+                on:click={() => switchTabs(Tab.myWork)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.myWork && 'tab-active'}">My Work ({myWorkContents.length})</button
+            >
+            <button
+                on:click={() => switchTabs(Tab.toAssign)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.toAssign && 'tab-active'}"
+                >To Assign ({toAssignContents.length})</button
+            >
+            <button
+                on:click={() => switchTabs(Tab.manage)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.manage && 'tab-active'}">Manage ({manageContents.length})</button
+            >
         </div>
-        <div class="mt-4 flex gap-4">
-            <input class="input input-bordered max-w-xs focus:outline-none" bind:value={search} placeholder="Search" />
+    </div>
+    <div class="mt-4 flex gap-4">
+        <input class="input input-bordered max-w-xs focus:outline-none" bind:value={search} placeholder="Search" />
+        <Select
+            class="select select-bordered max-w-[14rem] flex-grow"
+            bind:value={$searchParams.project}
+            onChange={resetSelections}
+            isNumber={false}
+            options={[{ value: '', label: 'Project' }, ...currentProjectNames.map((p) => ({ value: p, label: p }))]}
+        />
+        {#if $searchParams.tab === Tab.manage || $searchParams.tab === Tab.myWork}
             <Select
                 class="select select-bordered max-w-[14rem] flex-grow"
-                bind:value={$searchParams.project}
+                bind:value={$searchParams.lastAssignedId}
                 onChange={resetSelections}
-                isNumber={false}
-                options={[{ value: '', label: 'Project' }, ...currentProjectNames.map((p) => ({ value: p, label: p }))]}
+                isNumber={true}
+                options={[
+                    { value: 0, label: 'Last Assigned' },
+                    ...currentLastAssignedUsers.map((n) => ({ value: n.id, label: n.name })),
+                ]}
             />
-            {#if $searchParams.tab === Tab.manage || $searchParams.tab === Tab.myWork}
-                <Select
-                    class="select select-bordered max-w-[14rem] flex-grow"
-                    bind:value={$searchParams.lastAssignedId}
-                    onChange={resetSelections}
-                    isNumber={true}
-                    options={[
-                        { value: 0, label: 'Last Assigned' },
-                        ...currentLastAssignedUsers.map((n) => ({ value: n.id, label: n.name })),
-                    ]}
-                />
-            {/if}
-            {#if $searchParams.tab === Tab.manage}
-                <Select
-                    class="select select-bordered max-w-[14rem] flex-grow"
-                    bind:value={$searchParams.assignedUserId}
-                    onChange={resetSelections}
-                    isNumber={true}
-                    options={[
-                        { value: 0, label: 'Assigned' },
-                        ...(data.users || []).map((u) => ({ value: u.id, label: u.name })),
-                    ]}
-                />
-            {/if}
+        {/if}
+        {#if $searchParams.tab === Tab.manage}
+            <Select
+                class="select select-bordered max-w-[14rem] flex-grow"
+                bind:value={$searchParams.assignedUserId}
+                onChange={resetSelections}
+                isNumber={true}
+                options={[
+                    { value: 0, label: 'Assigned' },
+                    ...(data.users || []).map((u) => ({ value: u.id, label: u.name })),
+                ]}
+            />
+        {/if}
 
-            <button
-                data-app-insights-event-name="manager-dashboard-bulk-assign-click"
-                class="btn btn-primary"
-                on:click={() => (isAssignContentModalOpen = true)}
-                disabled={selectedMyWorkContents.length === 0 &&
-                    selectedToAssignContents.length === 0 &&
-                    selectedManageContents.length === 0}>Assign</button
-            >
-
-            {#if $searchParams.tab === Tab.myWork}
-                <Tooltip
-                    position={{ left: '10rem' }}
-                    text={nonCompanyReviewSelected ? 'Company Review status only' : null}
-                >
-                    <button
-                        data-app-insights-event-name="manager-dashboard-bulk-assign-click"
-                        class="btn btn-primary"
-                        on:click={() => (isSendToPublisherModalOpen = true)}
-                        disabled={!anyRowSelected || nonCompanyReviewSelected}>Send to Publisher</button
-                    >
-                </Tooltip>
-            {/if}
-            <div class="my-1 ml-auto flex flex-col items-end justify-center">
-                <div class="text-sm text-gray-500">Selected Items: {selectedCount ?? 0}</div>
-                <div class="text-sm text-gray-500">Selected Word Count: {selectedWordCount ?? 0}</div>
-            </div>
-        </div>
+        <button
+            data-app-insights-event-name="manager-dashboard-bulk-assign-click"
+            class="btn btn-primary"
+            on:click={() => (isAssignContentModalOpen = true)}
+            disabled={selectedMyWorkContents.length === 0 &&
+                selectedToAssignContents.length === 0 &&
+                selectedManageContents.length === 0}>Assign</button
+        >
 
         {#if $searchParams.tab === Tab.myWork}
+            <Tooltip position={{ left: '10rem' }} text={nonCompanyReviewSelected ? 'Company Review status only' : null}>
+                <button
+                    data-app-insights-event-name="manager-dashboard-bulk-assign-click"
+                    class="btn btn-primary"
+                    on:click={() => (isSendToPublisherModalOpen = true)}
+                    disabled={!anyRowSelected || nonCompanyReviewSelected}>Send to Publisher</button
+                >
+            </Tooltip>
+        {/if}
+        <div class="my-1 ml-auto flex flex-col items-end justify-center">
+            <div class="text-sm text-gray-500">Selected Items: {selectedCount ?? 0}</div>
+            <div class="text-sm text-gray-500">Selected Word Count: {selectedWordCount ?? 0}</div>
+        </div>
+    </div>
+
+    {#if $searchParams.tab === Tab.myWork}
+        <Table
+            bind:this={table}
+            class="my-4"
+            enableSelectAll={true}
+            columns={assignedContentsColumns}
+            items={sortAssignedData(currentMyWorkContents, $searchParams.sort)}
+            itemUrlPrefix="/resources/"
+            idColumn="id"
+            bind:searchParams={$searchParams}
+            bind:selectedItems={selectedMyWorkContents}
+            noItemsText="Your work is all done!"
+            searchable={true}
+            bind:searchText={search}
+            let:item
+            let:href
+            let:itemKey
+        >
+            {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
+                <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
+            {:else if itemKey === 'daysUntilProjectDeadline' && item[itemKey] !== null}
+                <LinkedTableCell {href} class={(item[itemKey] ?? 0) < 0 ? 'text-error' : ''}
+                    >{item[itemKey] ?? ''}</LinkedTableCell
+                >
+            {:else if itemKey === 'lastAssignedUser'}
+                <LinkedTableCell {href}>{item[itemKey]?.name ?? ''}</LinkedTableCell>
+            {:else if href !== undefined && itemKey}
+                <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+            {:else if itemKey}
+                <TableCell>{item[itemKey] ?? ''}</TableCell>
+            {/if}
+        </Table>
+    {:else if $searchParams.tab === Tab.toAssign}
+        <div class="flex h-full flex-[2] grow flex-col gap-4 overflow-y-hidden xl:flex-row">
             <Table
                 bind:this={table}
-                class="my-4"
+                class="my-4 max-h-[31.25rem] xl:grow"
                 enableSelectAll={true}
-                columns={assignedContentsColumns}
-                items={sortAssignedData(currentMyWorkContents, $searchParams.sort)}
-                itemUrlPrefix="/resources/"
+                columns={toAssignContentsColumns}
+                items={sortAssignedData(currentToAssignContents, $searchParams.sort)}
                 idColumn="id"
                 bind:searchParams={$searchParams}
-                bind:selectedItems={selectedMyWorkContents}
+                bind:selectedItems={selectedToAssignContents}
+                itemUrlPrefix="/resources/"
                 noItemsText="Your work is all done!"
                 searchable={true}
                 bind:searchText={search}
@@ -407,6 +426,53 @@
                     <LinkedTableCell {href} class={(item[itemKey] ?? 0) < 0 ? 'text-error' : ''}
                         >{item[itemKey] ?? ''}</LinkedTableCell
                     >
+                {:else if href !== undefined && itemKey}
+                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+                {:else if itemKey}
+                    <TableCell>{item[itemKey] ?? ''}</TableCell>
+                {/if}
+            </Table>
+            {#if userWordCounts.length > 0}
+                <Table
+                    bind:this={userWordCountTable}
+                    class="my-4 w-full xl:max-w-[275px]"
+                    columns={userWordCountColumns}
+                    items={sortUserWordCountData(userWordCounts, userWordCountParams.sort)}
+                    idColumn="userId"
+                    noItemsText="No Users Found."
+                    bind:searchParams={userWordCountParams}
+                ></Table>
+            {/if}
+        </div>
+    {:else if $searchParams.tab === Tab.manage}
+        <div class="flex h-full flex-[2] grow flex-col gap-4 overflow-y-hidden xl:flex-row">
+            <Table
+                bind:this={table}
+                class="my-4 max-h-[31.25rem] xl:grow"
+                enableSelectAll={true}
+                columns={manageContentsColumns}
+                items={sortAndFilterManageData(currentManageContents, $searchParams)}
+                idColumn="id"
+                bind:searchParams={$searchParams}
+                bind:selectedItems={selectedManageContents}
+                itemUrlPrefix="/resources/"
+                noItemsText={$searchParams.assignedUserId === 0
+                    ? 'Your work is all done!'
+                    : 'Nothing assigned to this user.'}
+                searchable={true}
+                bind:searchText={search}
+                let:item
+                let:href
+                let:itemKey
+            >
+                {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
+                    <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
+                {:else if itemKey === 'assignedUser' && item[itemKey] !== null && item[itemKey]?.name !== null}
+                    <LinkedTableCell {href}>{item[itemKey]?.name}</LinkedTableCell>
+                {:else if itemKey === 'daysUntilProjectDeadline' && item[itemKey] !== null}
+                    <LinkedTableCell {href} class={(item[itemKey] ?? 0) < 0 ? 'text-error' : ''}
+                        >{item[itemKey] ?? ''}</LinkedTableCell
+                    >
                 {:else if itemKey === 'lastAssignedUser'}
                     <LinkedTableCell {href}>{item[itemKey]?.name ?? ''}</LinkedTableCell>
                 {:else if href !== undefined && itemKey}
@@ -415,103 +481,20 @@
                     <TableCell>{item[itemKey] ?? ''}</TableCell>
                 {/if}
             </Table>
-        {:else if $searchParams.tab === Tab.toAssign}
-            <div class="flex h-full flex-[2] grow flex-col gap-4 overflow-y-hidden xl:flex-row">
+            {#if userWordCounts.length > 0}
                 <Table
-                    bind:this={table}
-                    class="my-4 max-h-[31.25rem] xl:grow"
-                    enableSelectAll={true}
-                    columns={toAssignContentsColumns}
-                    items={sortAssignedData(currentToAssignContents, $searchParams.sort)}
-                    idColumn="id"
-                    bind:searchParams={$searchParams}
-                    bind:selectedItems={selectedToAssignContents}
-                    itemUrlPrefix="/resources/"
-                    noItemsText="Your work is all done!"
-                    searchable={true}
-                    bind:searchText={search}
-                    let:item
-                    let:href
-                    let:itemKey
-                >
-                    {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
-                        <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
-                    {:else if itemKey === 'daysUntilProjectDeadline' && item[itemKey] !== null}
-                        <LinkedTableCell {href} class={(item[itemKey] ?? 0) < 0 ? 'text-error' : ''}
-                            >{item[itemKey] ?? ''}</LinkedTableCell
-                        >
-                    {:else if href !== undefined && itemKey}
-                        <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                    {:else if itemKey}
-                        <TableCell>{item[itemKey] ?? ''}</TableCell>
-                    {/if}
-                </Table>
-                {#if userWordCounts.length > 0}
-                    <Table
-                        bind:this={userWordCountTable}
-                        class="my-4 w-full xl:max-w-[275px]"
-                        columns={userWordCountColumns}
-                        items={sortUserWordCountData(userWordCounts, userWordCountParams.sort)}
-                        idColumn="userId"
-                        noItemsText="No Users Found."
-                        bind:searchParams={userWordCountParams}
-                    ></Table>
-                {/if}
-            </div>
-        {:else if $searchParams.tab === Tab.manage}
-            <div class="flex h-full flex-[2] grow flex-col gap-4 overflow-y-hidden xl:flex-row">
-                <Table
-                    bind:this={table}
-                    class="my-4 max-h-[31.25rem] xl:grow"
-                    enableSelectAll={true}
-                    columns={manageContentsColumns}
-                    items={sortAndFilterManageData(currentManageContents, $searchParams)}
-                    idColumn="id"
-                    bind:searchParams={$searchParams}
-                    bind:selectedItems={selectedManageContents}
-                    itemUrlPrefix="/resources/"
-                    noItemsText={$searchParams.assignedUserId === 0
-                        ? 'Your work is all done!'
-                        : 'Nothing assigned to this user.'}
-                    searchable={true}
-                    bind:searchText={search}
-                    let:item
-                    let:href
-                    let:itemKey
-                >
-                    {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
-                        <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
-                    {:else if itemKey === 'assignedUser' && item[itemKey] !== null && item[itemKey]?.name !== null}
-                        <LinkedTableCell {href}>{item[itemKey]?.name}</LinkedTableCell>
-                    {:else if itemKey === 'daysUntilProjectDeadline' && item[itemKey] !== null}
-                        <LinkedTableCell {href} class={(item[itemKey] ?? 0) < 0 ? 'text-error' : ''}
-                            >{item[itemKey] ?? ''}</LinkedTableCell
-                        >
-                    {:else if itemKey === 'lastAssignedUser'}
-                        <LinkedTableCell {href}>{item[itemKey]?.name ?? ''}</LinkedTableCell>
-                    {:else if href !== undefined && itemKey}
-                        <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                    {:else if itemKey}
-                        <TableCell>{item[itemKey] ?? ''}</TableCell>
-                    {/if}
-                </Table>
-                {#if userWordCounts.length > 0}
-                    <Table
-                        bind:this={userWordCountTable}
-                        class="my-4 w-full xl:max-w-[275px]"
-                        columns={userWordCountColumns}
-                        items={sortUserWordCountData(userWordCounts, userWordCountParams.sort)}
-                        idColumn="userId"
-                        noItemsText="No Users Found."
-                        bind:searchParams={userWordCountParams}
-                    ></Table>
-                {/if}
-            </div>
-        {/if}
-    </div>
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+                    bind:this={userWordCountTable}
+                    class="my-4 w-full xl:max-w-[275px]"
+                    columns={userWordCountColumns}
+                    items={sortUserWordCountData(userWordCounts, userWordCountParams.sort)}
+                    idColumn="userId"
+                    noItemsText="No Users Found."
+                    bind:searchParams={userWordCountParams}
+                ></Table>
+            {/if}
+        </div>
+    {/if}
+</div>
 
 <Modal
     isTransacting={isAssigning}

--- a/src/routes/(dashboard)/PublisherDashboard.svelte
+++ b/src/routes/(dashboard)/PublisherDashboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { PageData } from './$types';
     import { searchParameters, ssp } from '$lib/utils/sveltekit-search-params';
-    import type { Project, ResourceAssignedToSelf, ResourcePendingReview, NotApplicableContent } from './+page';
+    import type { Project, ResourceAssignedToSelf, ResourcePendingReview } from './+page';
     import { ResourceContentStatusEnum, UserRole } from '$lib/types/base';
     import { postToApi } from '$lib/utils/http-service';
     import Select from '$lib/components/Select.svelte';
@@ -27,9 +27,8 @@
     import TableCell from '$lib/components/TableCell.svelte';
     import ProjectProgressBar from '$lib/components/ProjectProgressBar.svelte';
     import { filterBoolean } from '$lib/utils/array';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
-    import ErrorMessage from '$lib/components/ErrorMessage.svelte';
     import { ResourceContentVersionReviewLevel } from '$lib/types/resources';
+    import type { NotApplicableContent } from './+page';
 
     enum Tab {
         myWork = 'my-work',
@@ -39,21 +38,35 @@
         notApplicable = 'not-applicable',
     }
 
-    let assignedContents: ResourceAssignedToSelf[] = [];
-    let reviewPendingContents: ResourcePendingReview[] = [];
-    let assignedProjects: Project[] = [];
-    let communityPendingContents: ResourcePendingReview[] = [];
-    let notApplicableContent: NotApplicableContent[] = [];
     let currentAssignedContents: ResourceAssignedToSelf[] = [];
     let currentReviewPendingContents: ResourcePendingReview[] = [];
     let currentAssignedProjects: Project[] = [];
     let currentCommunityPendingContents: ResourcePendingReview[] = [];
+    let selectedMyWorkTableItems: ResourceAssignedToSelf[] = [];
+    let selectedReviewPendingTableItems: ResourcePendingReview[] = [];
+    let selectedCommunityPendingTableItems: ResourcePendingReview[] = [];
+    let assignToUserId: number | null = null;
+    let isAssignContentModalOpen = false;
+    let isConfirmPublishModalOpen = false;
+    let errorModalText: string | undefined;
+    let isTransacting = false;
 
     const sortAssignedResourceData = createPublisherDashboardMyWorkSorter();
     const sortPendingData = createPublisherDashboardReviewPendingSorter();
     const sortAssignedProjectData = createPublisherDashboardProjectsSorter();
 
     export let data: PageData;
+
+    $: assignedContents = data.publisherDashboard!.assignedResourceContent;
+    $: allReviewPendingContents = data.publisherDashboard!.reviewPendingResourceContent;
+    $: assignedProjects = data.publisherDashboard!.assignedProjects;
+    $: notApplicableContent = data.publisherDashboard!.notApplicableContent;
+    $: communityPendingContents = allReviewPendingContents.filter((item) => {
+        return item.reviewLevel === ResourceContentVersionReviewLevel.community;
+    });
+    $: reviewPendingContents = allReviewPendingContents.filter((item) => {
+        return item.reviewLevel !== ResourceContentVersionReviewLevel.community;
+    });
 
     let search = '';
 
@@ -66,15 +79,6 @@
         },
         { runLoadAgainWhenParamsChange: false }
     );
-
-    let selectedMyWorkTableItems: ResourceAssignedToSelf[] = [];
-    let selectedReviewPendingTableItems: ResourcePendingReview[] = [];
-    let selectedCommunityPendingTableItems: ResourcePendingReview[] = [];
-    let assignToUserId: number | null = null;
-    let isAssignContentModalOpen = false;
-    let isConfirmPublishModalOpen = false;
-    let errorModalText: string | undefined;
-    let isTransacting = false;
 
     $: $searchParams.tab && resetSelection();
 
@@ -116,7 +120,7 @@
             selectedReviewContentIds.push(item.id);
         });
 
-        const inProgessAssignments =
+        const inProgressAssignments =
             selectedEditorReviewContentIds.length > 0
                 ? postToApi<null>('/resources/content/send-for-editor-review', {
                       assignedUserId: assignToUserId,
@@ -132,7 +136,7 @@
                 : Promise.resolve(null);
 
         try {
-            await Promise.all([inProgessAssignments, inReviewAssignments]);
+            await Promise.all([inProgressAssignments, inReviewAssignments]);
             isTransacting = false;
             window.location.reload();
         } catch {
@@ -162,23 +166,6 @@
         return Array.from(new Set(filterBoolean(contents.map((c) => c.statusDisplayName)))).sort();
     }
 
-    const allDataPromise = async () => {
-        [assignedContents, reviewPendingContents, assignedProjects, notApplicableContent] = await Promise.all([
-            data.publisherDashboard!.assignedResourceContent.promise,
-            data.publisherDashboard!.reviewPendingResourceContent.promise,
-            data.publisherDashboard!.assignedProjects.promise,
-            data.publisherDashboard!.notApplicableContent.promise,
-        ]);
-
-        communityPendingContents = reviewPendingContents.filter((item) => {
-            return item.reviewLevel === ResourceContentVersionReviewLevel.community;
-        });
-
-        reviewPendingContents = reviewPendingContents.filter((item) => {
-            return item.reviewLevel !== ResourceContentVersionReviewLevel.community;
-        });
-    };
-
     $: nonPublisherReviewSelected = selectedMyWorkTableItems.some(
         (i) =>
             ![
@@ -187,8 +174,12 @@
             ].includes(i.statusValue)
     );
 
-    // eslint-disable-next-line
-    let table: Table<any> | null;
+    let table:
+        | Table<ResourceAssignedToSelf>
+        | Table<Project>
+        | Table<ResourcePendingReview>
+        | Table<NotApplicableContent>
+        | undefined;
     $: $searchParams.sort && table?.resetScroll();
     $: clearStaleSearchParams($searchParams.tab, assignedContents, reviewPendingContents);
 
@@ -258,243 +249,229 @@
     $: setTabContents($searchParams.tab, search, $searchParams.status, $searchParams.project);
 </script>
 
-{#await allDataPromise()}
-    <CenteredSpinnerFullScreen />
-{:then _}
-    <div class="flex flex-col overflow-y-hidden px-4">
-        <h1 class="pt-4 text-3xl">Dashboard</h1>
-        <div class="flex flex-row items-center pt-4">
-            <div role="tablist" class="tabs tabs-bordered w-fit">
-                <button
-                    on:click={selectTab(Tab.myWork)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.myWork && 'tab-active'}"
-                    >My Work ({assignedContents.length})</button
-                >
-                <button
-                    on:click={selectTab(Tab.reviewPending)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.reviewPending && 'tab-active'}"
-                    >Review Pending ({reviewPendingContents.length})</button
-                >
-                <button
-                    on:click={selectTab(Tab.myProjects)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.myProjects && 'tab-active'}"
-                    >My Projects ({assignedProjects.length})</button
-                >
-                <button
-                    on:click={selectTab(Tab.community)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.community && 'tab-active'}"
-                >
-                    Community Pending ({communityPendingContents.length})
-                </button>
-                <button
-                    on:click={selectTab(Tab.notApplicable)}
-                    role="tab"
-                    class="tab {$searchParams.tab === Tab.notApplicable && 'tab-active'}"
-                >
-                    Not Applicable ({notApplicableContent.length})
-                </button>
-            </div>
-        </div>
-        {#if $searchParams.tab === Tab.myWork || $searchParams.tab === Tab.reviewPending || $searchParams.tab === Tab.community}
-            <div class="mt-4 flex space-x-4">
-                <input
-                    class="input input-bordered max-w-xs focus:outline-none"
-                    bind:value={search}
-                    placeholder="Search"
-                />
-                {#if $searchParams.tab === Tab.myWork}
-                    <Select
-                        class="select select-bordered max-w-[14rem] flex-grow"
-                        bind:value={$searchParams.status}
-                        onChange={resetSelection}
-                        options={[
-                            { value: '', label: 'Status' },
-                            ...statusesForContents(assignedContents).map((p) => ({ value: p, label: p })),
-                        ]}
-                    />
-                {/if}
-                {#if $searchParams.tab !== Tab.community}
-                    <Select
-                        class="select select-bordered max-w-[14rem] flex-grow"
-                        bind:value={$searchParams.project}
-                        onChange={resetSelection}
-                        options={[
-                            { value: '', label: 'Project' },
-                            ...projectNamesForContents(
-                                $searchParams.tab === Tab.myWork ? assignedContents : reviewPendingContents
-                            ).map((p) => ({ value: p, label: p })),
-                        ]}
-                    />
-                {/if}
-                <button
-                    data-app-insights-event-name="publisher-dashboard-bulk-assign-click"
-                    class="btn btn-primary"
-                    on:click={() => (isAssignContentModalOpen = true)}
-                    disabled={selectedReviewPendingTableItems.length === 0 &&
-                        selectedMyWorkTableItems.length === 0 &&
-                        selectedCommunityPendingTableItems.length === 0}
-                    >Assign
-                </button>
-                {#if $searchParams.tab === Tab.myWork}
-                    <Tooltip
-                        position={{ left: '7rem' }}
-                        text={nonPublisherReviewSelected ? 'Publisher Review status only' : null}
-                    >
-                        <button
-                            data-app-insights-event-name="publisher-dashboard-bulk-publish-click"
-                            class="btn btn-primary ms-4"
-                            on:click={() => (isConfirmPublishModalOpen = true)}
-                            disabled={selectedMyWorkTableItems.length === 0 || nonPublisherReviewSelected}
-                            >Publish
-                        </button>
-                    </Tooltip>
-                {/if}
-            </div>
-        {/if}
-        {#if $searchParams.tab === Tab.myProjects}
-            <div class="mt-4 flex flex-row">
-                <input
-                    class="input input-bordered max-w-xs focus:outline-none"
-                    bind:value={search}
-                    placeholder="Search"
-                />
-                <a class="btn btn-primary ms-4" href="/projects/new">Create Project</a>
-            </div>
-        {/if}
-        <div class="flex flex-row space-x-4 overflow-y-hidden">
-            {#if $searchParams.tab === Tab.myWork}
-                <Table
-                    bind:this={table}
-                    class="my-4"
-                    enableSelectAll={true}
-                    columns={assignedContentsColumns}
-                    items={sortAssignedResourceData(currentAssignedContents, $searchParams.sort)}
-                    idColumn="id"
-                    itemUrlPrefix="/resources/"
-                    bind:searchParams={$searchParams}
-                    bind:selectedItems={selectedMyWorkTableItems}
-                    noItemsText="Your work is all done!"
-                    searchable={true}
-                    bind:searchText={search}
-                    let:item
-                    let:href
-                    let:itemKey
-                >
-                    {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
-                        <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
-                    {:else if href !== undefined && itemKey}
-                        <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                    {:else if itemKey}
-                        <TableCell>{item[itemKey] ?? ''}</TableCell>
-                    {/if}
-                </Table>
-            {:else if $searchParams.tab === Tab.reviewPending}
-                <Table
-                    bind:this={table}
-                    class="my-4"
-                    enableSelectAll={true}
-                    columns={reviewPendingContentsColumns}
-                    items={sortPendingData(currentReviewPendingContents, $searchParams.sort)}
-                    idColumn="id"
-                    itemUrlPrefix="/resources/"
-                    bind:searchParams={$searchParams}
-                    bind:selectedItems={selectedReviewPendingTableItems}
-                    noItemsText="No items pending review."
-                    searchable={true}
-                    bind:searchText={search}
-                    let:item
-                    let:href
-                    let:itemKey
-                >
-                    {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
-                        <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
-                    {:else if href !== undefined && itemKey}
-                        <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                    {:else if itemKey}
-                        <TableCell>{item[itemKey] ?? ''}</TableCell>
-                    {/if}
-                </Table>
-            {:else if $searchParams.tab === Tab.myProjects}
-                <Table
-                    bind:this={table}
-                    class="my-4"
-                    enableSelectAll={false}
-                    columns={projectColumns}
-                    items={sortAssignedProjectData(currentAssignedProjects, $searchParams.sort)}
-                    idColumn="id"
-                    itemUrlPrefix="/projects/"
-                    bind:searchParams={$searchParams}
-                    noItemsText="No projects assigned to you."
-                    searchable={true}
-                    let:item
-                    let:href
-                    let:itemKey
-                    let:columnText
-                >
-                    {#if columnText === 'Progress'}
-                        <td>
-                            <ProjectProgressBar
-                                notStartedCount={item?.counts?.notStarted ?? 0}
-                                editorReviewCount={item?.counts?.editorReview ?? 0}
-                                inCompanyReviewCount={item?.counts?.inCompanyReview ?? 0}
-                                inPublisherReviewCount={item?.counts?.inPublisherReview ?? 0}
-                                completeCount={item?.counts?.completed ?? 0}
-                                showLegend={false}
-                            />
-                        </td>
-                    {:else if href !== undefined && itemKey}
-                        <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                    {:else if itemKey}
-                        <TableCell>{item[itemKey] ?? ''}</TableCell>
-                    {/if}
-                </Table>
-            {:else if $searchParams.tab === Tab.community}
-                <Table
-                    bind:this={table}
-                    class="my-4"
-                    enableSelectAll={true}
-                    columns={communityPendingContentsColumns}
-                    items={sortPendingData(currentCommunityPendingContents, $searchParams.sort)}
-                    idColumn="id"
-                    itemUrlPrefix="/resources/"
-                    bind:searchParams={$searchParams}
-                    bind:selectedItems={selectedCommunityPendingTableItems}
-                    noItemsText="No items pending review."
-                    searchable={true}
-                    bind:searchText={search}
-                    let:item
-                    let:href
-                    let:itemKey
-                >
-                    {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
-                        <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
-                    {:else if href !== undefined && itemKey}
-                        <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
-                    {:else if itemKey}
-                        <TableCell>{item[itemKey] ?? ''}</TableCell>
-                    {/if}
-                </Table>
-            {:else if $searchParams.tab === Tab.notApplicable}
-                <Table
-                    bind:this={table}
-                    class="my-4"
-                    enableSelectAll={false}
-                    columns={notApplicableContentsColumns}
-                    items={notApplicableContent}
-                    idColumn="id"
-                    itemUrlPrefix="/resources/"
-                    noItemsText="No items pending review."
-                />
-            {/if}
+<div class="flex flex-col overflow-y-hidden px-4">
+    <h1 class="pt-4 text-3xl">Dashboard</h1>
+    <div class="flex flex-row items-center pt-4">
+        <div role="tablist" class="tabs tabs-bordered w-fit">
+            <button
+                on:click={selectTab(Tab.myWork)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.myWork && 'tab-active'}"
+                >My Work ({assignedContents.length})</button
+            >
+            <button
+                on:click={selectTab(Tab.reviewPending)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.reviewPending && 'tab-active'}"
+                >Review Pending ({reviewPendingContents.length})</button
+            >
+            <button
+                on:click={selectTab(Tab.myProjects)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.myProjects && 'tab-active'}"
+                >My Projects ({assignedProjects.length})</button
+            >
+            <button
+                on:click={selectTab(Tab.community)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.community && 'tab-active'}"
+            >
+                Community Pending ({communityPendingContents.length})
+            </button>
+            <button
+                on:click={selectTab(Tab.notApplicable)}
+                role="tab"
+                class="tab {$searchParams.tab === Tab.notApplicable && 'tab-active'}"
+            >
+                Not Applicable ({notApplicableContent.length})
+            </button>
         </div>
     </div>
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+    {#if $searchParams.tab === Tab.myWork || $searchParams.tab === Tab.reviewPending || $searchParams.tab === Tab.community}
+        <div class="mt-4 flex space-x-4">
+            <input class="input input-bordered max-w-xs focus:outline-none" bind:value={search} placeholder="Search" />
+            {#if $searchParams.tab === Tab.myWork}
+                <Select
+                    class="select select-bordered max-w-[14rem] flex-grow"
+                    bind:value={$searchParams.status}
+                    onChange={resetSelection}
+                    options={[
+                        { value: '', label: 'Status' },
+                        ...statusesForContents(assignedContents).map((p) => ({ value: p, label: p })),
+                    ]}
+                />
+            {/if}
+            {#if $searchParams.tab !== Tab.community}
+                <Select
+                    class="select select-bordered max-w-[14rem] flex-grow"
+                    bind:value={$searchParams.project}
+                    onChange={resetSelection}
+                    options={[
+                        { value: '', label: 'Project' },
+                        ...projectNamesForContents(
+                            $searchParams.tab === Tab.myWork ? assignedContents : reviewPendingContents
+                        ).map((p) => ({ value: p, label: p })),
+                    ]}
+                />
+            {/if}
+            <button
+                data-app-insights-event-name="publisher-dashboard-bulk-assign-click"
+                class="btn btn-primary"
+                on:click={() => (isAssignContentModalOpen = true)}
+                disabled={selectedReviewPendingTableItems.length === 0 &&
+                    selectedMyWorkTableItems.length === 0 &&
+                    selectedCommunityPendingTableItems.length === 0}
+                >Assign
+            </button>
+            {#if $searchParams.tab === Tab.myWork}
+                <Tooltip
+                    position={{ left: '7rem' }}
+                    text={nonPublisherReviewSelected ? 'Publisher Review status only' : null}
+                >
+                    <button
+                        data-app-insights-event-name="publisher-dashboard-bulk-publish-click"
+                        class="btn btn-primary ms-4"
+                        on:click={() => (isConfirmPublishModalOpen = true)}
+                        disabled={selectedMyWorkTableItems.length === 0 || nonPublisherReviewSelected}
+                        >Publish
+                    </button>
+                </Tooltip>
+            {/if}
+        </div>
+    {/if}
+    {#if $searchParams.tab === Tab.myProjects}
+        <div class="mt-4 flex flex-row">
+            <input class="input input-bordered max-w-xs focus:outline-none" bind:value={search} placeholder="Search" />
+            <a class="btn btn-primary ms-4" href="/projects/new">Create Project</a>
+        </div>
+    {/if}
+    <div class="flex flex-row space-x-4 overflow-y-hidden">
+        {#if $searchParams.tab === Tab.myWork}
+            <Table
+                bind:this={table}
+                class="my-4"
+                enableSelectAll={true}
+                columns={assignedContentsColumns}
+                items={sortAssignedResourceData(currentAssignedContents, $searchParams.sort)}
+                idColumn="id"
+                itemUrlPrefix="/resources/"
+                bind:searchParams={$searchParams}
+                bind:selectedItems={selectedMyWorkTableItems}
+                noItemsText="Your work is all done!"
+                searchable={true}
+                bind:searchText={search}
+                let:item
+                let:href
+                let:itemKey
+            >
+                {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
+                    <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
+                {:else if href !== undefined && itemKey}
+                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+                {:else if itemKey}
+                    <TableCell>{item[itemKey] ?? ''}</TableCell>
+                {/if}
+            </Table>
+        {:else if $searchParams.tab === Tab.reviewPending}
+            <Table
+                bind:this={table}
+                class="my-4"
+                enableSelectAll={true}
+                columns={reviewPendingContentsColumns}
+                items={sortPendingData(currentReviewPendingContents, $searchParams.sort)}
+                idColumn="id"
+                itemUrlPrefix="/resources/"
+                bind:searchParams={$searchParams}
+                bind:selectedItems={selectedReviewPendingTableItems}
+                noItemsText="No items pending review."
+                searchable={true}
+                bind:searchText={search}
+                let:item
+                let:href
+                let:itemKey
+            >
+                {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
+                    <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
+                {:else if href !== undefined && itemKey}
+                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+                {:else if itemKey}
+                    <TableCell>{item[itemKey] ?? ''}</TableCell>
+                {/if}
+            </Table>
+        {:else if $searchParams.tab === Tab.myProjects}
+            <Table
+                bind:this={table}
+                class="my-4"
+                enableSelectAll={false}
+                columns={projectColumns}
+                items={sortAssignedProjectData(currentAssignedProjects, $searchParams.sort)}
+                idColumn="id"
+                itemUrlPrefix="/projects/"
+                bind:searchParams={$searchParams}
+                noItemsText="No projects assigned to you."
+                searchable={true}
+                let:item
+                let:href
+                let:itemKey
+                let:columnText
+            >
+                {#if columnText === 'Progress'}
+                    <td>
+                        <ProjectProgressBar
+                            notStartedCount={item?.counts?.notStarted ?? 0}
+                            editorReviewCount={item?.counts?.editorReview ?? 0}
+                            inCompanyReviewCount={item?.counts?.inCompanyReview ?? 0}
+                            inPublisherReviewCount={item?.counts?.inPublisherReview ?? 0}
+                            completeCount={item?.counts?.completed ?? 0}
+                            showLegend={false}
+                        />
+                    </td>
+                {:else if href !== undefined && itemKey}
+                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+                {:else if itemKey}
+                    <TableCell>{item[itemKey] ?? ''}</TableCell>
+                {/if}
+            </Table>
+        {:else if $searchParams.tab === Tab.community}
+            <Table
+                bind:this={table}
+                class="my-4"
+                enableSelectAll={true}
+                columns={communityPendingContentsColumns}
+                items={sortPendingData(currentCommunityPendingContents, $searchParams.sort)}
+                idColumn="id"
+                itemUrlPrefix="/resources/"
+                bind:searchParams={$searchParams}
+                bind:selectedItems={selectedCommunityPendingTableItems}
+                noItemsText="No items pending review."
+                searchable={true}
+                bind:searchText={search}
+                let:item
+                let:href
+                let:itemKey
+            >
+                {#if itemKey === 'daysSinceContentUpdated' && item[itemKey] !== null}
+                    <LinkedTableCell {href}>{formatSimpleDaysAgo(item[itemKey])}</LinkedTableCell>
+                {:else if href !== undefined && itemKey}
+                    <LinkedTableCell {href}>{item[itemKey] ?? ''}</LinkedTableCell>
+                {:else if itemKey}
+                    <TableCell>{item[itemKey] ?? ''}</TableCell>
+                {/if}
+            </Table>
+        {:else if $searchParams.tab === Tab.notApplicable}
+            <Table
+                bind:this={table}
+                class="my-4"
+                enableSelectAll={false}
+                columns={notApplicableContentsColumns}
+                items={notApplicableContent}
+                idColumn="id"
+                itemUrlPrefix="/resources/"
+                noItemsText="No items pending review."
+            />
+        {/if}
+    </div>
+</div>
 
 <Modal
     {isTransacting}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
     import { page } from '$app/stores';
     import ErrorMessage from '$lib/components/ErrorMessage.svelte';
+
+    /**
+     * This component handles error displays triggered by `src/hooks.client.ts` when errors
+     * occur within any `+page.ts#load` or `+layout.ts#load`.
+     */
 </script>
 
 <ErrorMessage uncastError={$page?.error} />

--- a/src/routes/help/+page.ts
+++ b/src/routes/help/+page.ts
@@ -1,13 +1,16 @@
 import type { HelpDocumentResponse } from '$lib/types/helpDocuments';
-import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
+import { getFromApi } from '$lib/utils/http-service';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
 
-    const helpContents = getFromApiWithoutBlocking<HelpDocumentResponse>('/help/aquifer-cms/documents', fetch);
+    const promise = getFromApi<HelpDocumentResponse>('/help/aquifer-cms/documents', fetch);
 
     return {
-        helpContents,
+        // by returning a nested object here, SvelteKit won't await the promise before rendering the
+        // +page.svelte and instead we can await the promise on the page to show a skeleton UI
+        // TODO: when upgrading to SvelteKit 2 the nested part isn't necessary, just return the unresolved promise
+        helpContents: { promise },
     };
 };

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,64 +1,45 @@
 <script lang="ts">
     import type { PageData } from './$types';
     import ProjectTable from '$lib/components/projects/ProjectTable.svelte';
-    import { ProjectStatusTab, type ProjectListResponse } from '$lib/types/projects';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
-    import ErrorMessage from '$lib/components/ErrorMessage.svelte';
+    import { ProjectStatusTab } from '$lib/types/projects';
     import ProjectTableTabs from '$lib/components/projects/ProjectTableTabs.svelte';
     import ProjectReportingTab from './ProjectReportingTab.svelte';
 
     export let data: PageData;
 
-    $: projectPromise = data.projectListResponse!.promise;
-    $: companiesPromise = data.companies!.promise;
-    $: languages = data.languages;
     let currentTab = ProjectStatusTab.active;
 
-    let activeProjects: ProjectListResponse[] = [];
-    let recentlyFinishedProjects: ProjectListResponse[] = [];
-    let notStartedProjects: ProjectListResponse[] = [];
-
-    $: handleFetchedProjects(projectPromise);
-
-    async function handleFetchedProjects(promise: typeof projectPromise) {
-        const projects = await promise;
-        activeProjects = projects.filter((p) => p.isStarted && !p.isCompleted);
-        recentlyFinishedProjects = projects.filter((p) => p.isCompleted);
-        notStartedProjects = projects.filter((p) => !p.isStarted);
-    }
+    $: languages = data.languages;
+    $: activeProjects = data.projects.filter((p) => p.isStarted && !p.isCompleted);
+    $: recentlyFinishedProjects = data.projects.filter((p) => p.isCompleted);
+    $: notStartedProjects = data.projects.filter((p) => !p.isStarted);
 </script>
 
 <svelte:head>
     <title>Projects | Aquifer Admin</title>
 </svelte:head>
 
-{#await Promise.all([projectPromise, companiesPromise])}
-    <CenteredSpinnerFullScreen />
-{:then [_, companiesResponse]}
-    <div class="flex h-full flex-col overflow-y-auto overflow-x-hidden px-4">
-        <div class="mb-6 mt-4 flex">
-            <h1 class="my-auto text-3xl">Projects</h1>
-        </div>
-
-        <ProjectTableTabs
-            activeCount={activeProjects.length}
-            recentlyFinishedCount={recentlyFinishedProjects.length}
-            notStartedCount={notStartedProjects.length}
-            bind:currentTab
-        />
-
-        <ProjectReportingTab isShowing={currentTab === ProjectStatusTab.reporting} companies={companiesResponse} />
-
-        <ProjectTable
-            isShowing={currentTab !== ProjectStatusTab.reporting}
-            {activeProjects}
-            {recentlyFinishedProjects}
-            {notStartedProjects}
-            companies={companiesResponse}
-            {currentTab}
-            {languages}
-        />
+<div class="flex h-full flex-col overflow-y-auto overflow-x-hidden px-4">
+    <div class="mb-6 mt-4 flex">
+        <h1 class="my-auto text-3xl">Projects</h1>
     </div>
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+
+    <ProjectTableTabs
+        activeCount={activeProjects.length}
+        recentlyFinishedCount={recentlyFinishedProjects.length}
+        notStartedCount={notStartedProjects.length}
+        bind:currentTab
+    />
+
+    <ProjectReportingTab isShowing={currentTab === ProjectStatusTab.reporting} companies={data.companies} />
+
+    <ProjectTable
+        isShowing={currentTab !== ProjectStatusTab.reporting}
+        {activeProjects}
+        {recentlyFinishedProjects}
+        {notStartedProjects}
+        companies={data.companies}
+        {currentTab}
+        {languages}
+    />
+</div>

--- a/src/routes/projects/+page.ts
+++ b/src/routes/projects/+page.ts
@@ -1,5 +1,5 @@
 import type { PageLoad } from './$types';
-import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
+import { getFromApi } from '$lib/utils/http-service';
 import type { ProjectListResponse } from '$lib/types/projects';
 import { Permission, userCan } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
@@ -10,12 +10,14 @@ export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
 
     if (get(userCan)(Permission.ReadProjects)) {
-        const projectListResponse = getFromApiWithoutBlocking<ProjectListResponse[]>('/projects', fetch);
-        const companies = getFromApiWithoutBlocking<Company[]>(`/companies`, fetch);
-        return { projectListResponse, companies };
+        const [projects, companies] = await Promise.all([
+            getFromApi<ProjectListResponse[]>('/projects', fetch),
+            getFromApi<Company[]>(`/companies`, fetch),
+        ]);
+        return { projects, companies };
     } else if (get(userCan)(Permission.ReadProjectsInCompany)) {
-        const projectListResponse = getFromApiWithoutBlocking<ProjectListResponse[]>('/projects', fetch);
-        return { projectListResponse, companies: { promise: Promise.resolve([]) } };
+        const projects = await getFromApi<ProjectListResponse[]>('/projects', fetch);
+        return { projects, companies: [] as Company[] };
     } else {
         throw redirect(302, '/');
     }

--- a/src/routes/projects/[projectId]/+page.ts
+++ b/src/routes/projects/[projectId]/+page.ts
@@ -1,17 +1,20 @@
 import type { PageLoad } from './$types';
-import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
+import { getFromApi } from '$lib/utils/http-service';
 import type { ProjectResponse } from '$lib/types/projects';
 import { Permission, userCan } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
+import errorGotoPath from '$lib/stores/error-goto-path';
 
 export const load: PageLoad = async ({ params, parent, fetch }) => {
     await parent();
-    const canOnlyViewProjectsInCompany =
-        get(userCan)(Permission.ReadProjectsInCompany) && !get(userCan)(Permission.ReadProjects);
+
+    errorGotoPath.set('/projects');
 
     if (get(userCan)(Permission.ReadProjects) || get(userCan)(Permission.ReadProjectsInCompany)) {
-        const projectResponse = getFromApiWithoutBlocking<ProjectResponse>(`/projects/${params.projectId}`, fetch);
+        const canOnlyViewProjectsInCompany =
+            get(userCan)(Permission.ReadProjectsInCompany) && !get(userCan)(Permission.ReadProjects);
+        const projectResponse = await getFromApi<ProjectResponse>(`/projects/${params.projectId}`, fetch);
         return { projectResponse, canOnlyViewProjectsInCompany };
     } else {
         throw redirect(302, '/');

--- a/src/routes/projects/new/+page.ts
+++ b/src/routes/projects/new/+page.ts
@@ -10,10 +10,15 @@ export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
 
     if (get(userCan)(Permission.CreateProject)) {
+        const [projectPlatforms, companies, bibleBooks] = await Promise.all([
+            getFromApi<ProjectPlatform[]>('/project-platforms', fetch),
+            getFromApi<Company[]>('/companies', fetch),
+            getFromApi<BibleBook[]>('/bibles/1/books', fetch),
+        ]);
         return {
-            projectPlatforms: sortByKey(await getFromApi<ProjectPlatform[]>('/project-platforms', fetch), 'name'),
-            companies: sortByKey(await getFromApi<Company[]>('/companies', fetch), 'name'),
-            bibleBooks: await getFromApi<BibleBook[]>('/bibles/1/books', fetch),
+            projectPlatforms: sortByKey(projectPlatforms, 'name'),
+            companies: sortByKey(companies, 'name'),
+            bibleBooks,
         };
     } else {
         throw redirect(302, '/');

--- a/src/routes/projects/new/ProjectContentSelector.svelte
+++ b/src/routes/projects/new/ProjectContentSelector.svelte
@@ -37,7 +37,7 @@
     $: chapters = parseNumbersListFromString(
         chaptersString,
         1,
-        bibleBooks?.find((b) => b.code === bookCode)?.totalChapters ?? 0
+        bibleBooks.find((b) => b.code === bookCode)?.totalChapters ?? 0
     );
 
     $: bookCode && (chaptersString = ''); // reset chapters if book code changes
@@ -123,7 +123,7 @@
                 class="select select-bordered"
                 options={[
                     { value: null, label: 'Select Book' },
-                    ...(bibleBooks || []).map((b) => ({ value: b.code, label: b.localizedName })),
+                    ...bibleBooks.map((b) => ({ value: b.code, label: b.localizedName })),
                 ]}
                 bind:value={bookCode}
             />

--- a/src/routes/reporting/+page.svelte
+++ b/src/routes/reporting/+page.svelte
@@ -8,15 +8,14 @@
     import ReportingLink from '$lib/components/reporting/ReportingLink.svelte';
     import ReportSummaryCard from '$lib/components/reporting/ReportSummaryCard.svelte';
     import MultipleSelect from '$lib/components/MultipleSelect.svelte';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
     import type { BasicDynamicReport } from '$lib/types/reporting';
-    import ErrorMessage from '$lib/components/ErrorMessage.svelte';
 
     export let data: PageData;
 
-    $: summaryPromise = data.summary!.promise;
-    $: resourceItemsSummaryPromise = data.resourceItemsSummary!.promise;
-    $: reportsPromise = data.reports!.promise;
+    $: summary = data.summary;
+    $: resourceItemsSummary = data.resourceItemsSummary;
+    $: reports = dynamicReports(data.reports);
+    $: languages = summary.languages.sort();
 
     const defaultSelection = 'default';
 
@@ -36,128 +35,119 @@
     <title>Reporting | Aquifer Admin</title>
 </svelte:head>
 
-{#await Promise.all([summaryPromise, resourceItemsSummaryPromise, reportsPromise])}
-    <CenteredSpinnerFullScreen />
-{:then [summary, resourceItemsSummary, reports]}
-    {@const languages = summary.languages.sort()}
-    {@const filteredReports = dynamicReports(reports)}
-
-    <div class="overflow-y-auto">
-        <div class="mx-4 mb-4 mt-4 text-3xl">Reporting</div>
-        <div class="mx-4 mb-4 grid grid-cols-3 gap-4">
-            <div class="col-span-2 max-h-[38.375rem] rounded border px-4 py-2 shadow-lg">
-                <Select
-                    bind:value={selectedChart}
-                    class="select select-bordered me-2 mt-2 w-auto"
-                    options={[
-                        { value: 'TotalResourcesAreaChart', label: 'Total Resource Items' },
-                        { value: 'TranslatedResourcesBarChart', label: 'Translated Resource Items' },
-                    ]}
-                />
-                <div class="mb-6 mt-4 flex flex-row space-x-2">
-                    <span>
-                        <MultipleSelect
-                            label={$translate('page.dashboard.dropdowns.allLanguages.value')}
-                            bind:values={selectedLanguages}
-                            class="w-[15rem]"
-                            options={[...languages.map((l) => ({ value: l, label: l }))]}
-                        />
-                    </span>
-                    <span>
-                        <Select
-                            bind:value={selectedResource}
-                            class="select select-bordered w-auto"
-                            options={[
-                                { value: 'default', label: $translate('page.dashboard.dropdowns.allResources.value') },
-                                ...summary.parentResourceNames.sort().map((l) => ({ value: l, label: l })),
-                            ]}
-                        />
-                    </span>
-                </div>
-                <div class="me-10 ms-5">
-                    {#if selectedChart === 'TotalResourcesAreaChart'}
-                        <TotalResourcesAreaChart
-                            {selectedLanguages}
-                            {selectedResource}
-                            resourcesByLanguage={summary.resourcesByLanguage}
-                            totalsByMonth={summary.totalsByMonth}
-                            resourcesByType={summary.resourcesByParentResource}
-                        />
-                    {:else if selectedChart === 'TranslatedResourcesBarChart'}
-                        <TranslatedResourcesBarChart
-                            {selectedLanguages}
-                            {selectedResource}
-                            resourcesByLanguage={summary.resourcesByLanguage}
-                            totalsByMonth={summary.totalsByMonth}
-                            {languages}
-                        />
-                    {/if}
-                </div>
+<div class="overflow-y-auto">
+    <div class="mx-4 mb-4 mt-4 text-3xl">Reporting</div>
+    <div class="mx-4 mb-4 grid grid-cols-3 gap-4">
+        <div class="col-span-2 max-h-[38.375rem] rounded border px-4 py-2 shadow-lg">
+            <Select
+                bind:value={selectedChart}
+                class="select select-bordered me-2 mt-2 w-auto"
+                options={[
+                    { value: 'TotalResourcesAreaChart', label: 'Total Resource Items' },
+                    { value: 'TranslatedResourcesBarChart', label: 'Translated Resource Items' },
+                ]}
+            />
+            <div class="mb-6 mt-4 flex flex-row space-x-2">
+                <span>
+                    <MultipleSelect
+                        label={$translate('page.dashboard.dropdowns.allLanguages.value')}
+                        bind:values={selectedLanguages}
+                        class="w-[15rem]"
+                        options={[...languages.map((l) => ({ value: l, label: l }))]}
+                    />
+                </span>
+                <span>
+                    <Select
+                        bind:value={selectedResource}
+                        class="select select-bordered w-auto"
+                        options={[
+                            { value: 'default', label: $translate('page.dashboard.dropdowns.allResources.value') },
+                            ...summary.parentResourceNames.sort().map((l) => ({ value: l, label: l })),
+                        ]}
+                    />
+                </span>
             </div>
-
-            <div>
-                <ReportSummaryCard
-                    addPlus={true}
-                    reportTitle="Total Resource Items"
-                    reportTotal={resourceItemsSummary.totalResources}
-                    monthTotal={resourceItemsSummary.totalResourcesThisMonth}
-                />
-                <ReportSummaryCard
-                    addPlus={true}
-                    reportTitle="Total Resource Items (non-English)"
-                    reportTotal={resourceItemsSummary.totalNonEnglishResources}
-                    monthTotal={resourceItemsSummary.totalNonEnglishResourcesThisMonth}
-                />
-                <ReportSummaryCard
-                    addPlus={true}
-                    reportTitle="Total Resource Items (2+ Languages)"
-                    reportTotal={resourceItemsSummary.totalResourcesTwoPlusLanguages}
-                    monthTotal={resourceItemsSummary.totalResourcesTwoPlusLanguagesThisMonth}
-                />
-                <ReportSummaryCard
-                    reportTitle="Resource Items being Aquiferized"
-                    reportTotal={resourceItemsSummary.aquiferizedResources}
-                    monthTotal={resourceItemsSummary.aquiferizedResourcesThisMonth}
-                    monthText="Started This Month"
-                />
-                <ReportSummaryCard
-                    reportTitle="Resource Items being Translated"
-                    reportTotal={resourceItemsSummary.totalResourceBeingTranslated}
-                    monthTotal={resourceItemsSummary.totalResourceBeingTranslatedThisMonth}
-                    monthText="Started This Month"
-                />
+            <div class="me-10 ms-5">
+                {#if selectedChart === 'TotalResourcesAreaChart'}
+                    <TotalResourcesAreaChart
+                        {selectedLanguages}
+                        {selectedResource}
+                        resourcesByLanguage={summary.resourcesByLanguage}
+                        totalsByMonth={summary.totalsByMonth}
+                        resourcesByType={summary.resourcesByParentResource}
+                    />
+                {:else if selectedChart === 'TranslatedResourcesBarChart'}
+                    <TranslatedResourcesBarChart
+                        {selectedLanguages}
+                        {selectedResource}
+                        resourcesByLanguage={summary.resourcesByLanguage}
+                        totalsByMonth={summary.totalsByMonth}
+                        {languages}
+                    />
+                {/if}
             </div>
         </div>
 
-        {#if filteredReports.length}
-            <div class="mx-4 mb-4 grid-cols-3">
-                <span class="me-2">View Report: </span>
-                <Select
-                    class="select select-bordered max-w-[14rem] flex-grow"
-                    value=""
-                    onChange={(slug) => {
-                        window.open(`/reporting/${slug}`, '_blank');
-                        return false;
-                    }}
-                    isNumber={false}
-                    options={[
-                        { value: '', label: 'Select Report' },
-                        ...filteredReports.map(({ name, slug }) => ({ value: slug, label: name })),
-                    ]}
-                />
-            </div>
-        {/if}
-
-        <div class="mx-4 mb-4 grid grid-cols-3 gap-4">
-            {#each reportingUiLinks.reports as link (link.reportLink)}
-                <ReportingLink
-                    reportTitle={link.reportTitle}
-                    reportDescription={link.reportDescription}
-                    reportLink={link.reportLink}
-                />
-            {/each}
+        <div>
+            <ReportSummaryCard
+                addPlus={true}
+                reportTitle="Total Resource Items"
+                reportTotal={resourceItemsSummary.totalResources}
+                monthTotal={resourceItemsSummary.totalResourcesThisMonth}
+            />
+            <ReportSummaryCard
+                addPlus={true}
+                reportTitle="Total Resource Items (non-English)"
+                reportTotal={resourceItemsSummary.totalNonEnglishResources}
+                monthTotal={resourceItemsSummary.totalNonEnglishResourcesThisMonth}
+            />
+            <ReportSummaryCard
+                addPlus={true}
+                reportTitle="Total Resource Items (2+ Languages)"
+                reportTotal={resourceItemsSummary.totalResourcesTwoPlusLanguages}
+                monthTotal={resourceItemsSummary.totalResourcesTwoPlusLanguagesThisMonth}
+            />
+            <ReportSummaryCard
+                reportTitle="Resource Items being Aquiferized"
+                reportTotal={resourceItemsSummary.aquiferizedResources}
+                monthTotal={resourceItemsSummary.aquiferizedResourcesThisMonth}
+                monthText="Started This Month"
+            />
+            <ReportSummaryCard
+                reportTitle="Resource Items being Translated"
+                reportTotal={resourceItemsSummary.totalResourceBeingTranslated}
+                monthTotal={resourceItemsSummary.totalResourceBeingTranslatedThisMonth}
+                monthText="Started This Month"
+            />
         </div>
     </div>
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+
+    {#if reports.length}
+        <div class="mx-4 mb-4 grid-cols-3">
+            <span class="me-2">View Report: </span>
+            <Select
+                class="select select-bordered max-w-[14rem] flex-grow"
+                value=""
+                onChange={(slug) => {
+                    window.open(`/reporting/${slug}`, '_blank');
+                    return false;
+                }}
+                isNumber={false}
+                options={[
+                    { value: '', label: 'Select Report' },
+                    ...reports.map(({ name, slug }) => ({ value: slug, label: name })),
+                ]}
+            />
+        </div>
+    {/if}
+
+    <div class="mx-4 mb-4 grid grid-cols-3 gap-4">
+        {#each reportingUiLinks.reports as link (link.reportLink)}
+            <ReportingLink
+                reportTitle={link.reportTitle}
+                reportDescription={link.reportDescription}
+                reportLink={link.reportLink}
+            />
+        {/each}
+    </div>
+</div>

--- a/src/routes/reporting/+page.ts
+++ b/src/routes/reporting/+page.ts
@@ -1,5 +1,5 @@
 import type { PageLoad } from './$types';
-import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
+import { getFromApi } from '$lib/utils/http-service';
 import type { ResourcesSummary, ResourceItemsSummary, BasicDynamicReport } from '$lib/types/reporting';
 import { Permission, userCan } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
@@ -9,15 +9,11 @@ export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
 
     if (get(userCan)(Permission.ReadReports)) {
-        const summary = getFromApiWithoutBlocking<ResourcesSummary>(
-            '/resources/content/general-reporting-summary',
-            fetch
-        );
-        const resourceItemsSummary = getFromApiWithoutBlocking<ResourceItemsSummary>(
-            '/reports/resources/item-totals',
-            fetch
-        );
-        const reports = getFromApiWithoutBlocking<BasicDynamicReport[]>('/reports/dynamic', fetch);
+        const [summary, resourceItemsSummary, reports] = await Promise.all([
+            getFromApi<ResourcesSummary>('/resources/content/general-reporting-summary', fetch),
+            getFromApi<ResourceItemsSummary>('/reports/resources/item-totals', fetch),
+            getFromApi<BasicDynamicReport[]>('/reports/dynamic', fetch),
+        ]);
         return { summary, reports, resourceItemsSummary };
     } else {
         throw redirect(302, '/');

--- a/src/routes/resources/+layout.ts
+++ b/src/routes/resources/+layout.ts
@@ -1,4 +1,4 @@
-import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
+import { getFromApi } from '$lib/utils/http-service';
 import type { BibleBook } from '$lib/types/base';
 import type { LayoutLoad } from './$types';
 
@@ -6,6 +6,6 @@ export const load: LayoutLoad = async ({ parent }) => {
     await parent();
 
     return {
-        bibleBooks: getFromApiWithoutBlocking<BibleBook[]>('/bibles/1/books', fetch),
+        bibleBooks: await getFromApi<BibleBook[]>('/bibles/1/books', fetch),
     };
 };

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -11,7 +11,6 @@
     import { numbersRangeToString, parseStartAndEndFromSingleOrRangeString } from '$lib/utils/number-list-parser';
     import type { BibleBook } from '$lib/types/base';
     import LinkedTableCell from '$lib/components/LinkedTableCell.svelte';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
     import ErrorMessage from '$lib/components/ErrorMessage.svelte';
 
     export let data: PageData;
@@ -21,14 +20,7 @@
     $: resourceContentDataPromise =
         data.resourceContentData === null ? Promise.resolve(null) : data.resourceContentData.promise;
 
-    $: bibleBooksPromise = data.bibleBooks.promise;
-    $: setBibleBooks(data.bibleBooks.promise);
-
-    async function setBibleBooks(bibleBooksPromise: Promise<BibleBook[]>) {
-        bibleBooks = await bibleBooksPromise;
-    }
-
-    let bibleBooks: BibleBook[] | null = null;
+    $: bibleBooks = data.bibleBooks;
 
     let searchInputValue = $searchParams.query;
     let languageId = $searchParams.languageId;
@@ -69,7 +61,7 @@
         }
     }
 
-    async function applyFilters() {
+    function applyFilters() {
         if (canApplyFilters) {
             const newIsPublished = !publishedChecked ? 'false' : !unpublishedChecked ? 'true' : '';
             const newBookCode = bookCode || '';
@@ -98,7 +90,7 @@
         return Math.ceil(totalResourceContents / $resourcesPerPage) || 1;
     }
 
-    function calculateChapterRange(bibleBooks: BibleBook[] | null) {
+    function calculateChapterRange(bibleBooks: BibleBook[]) {
         chapterRange = numbersRangeToString(
             $searchParams.startChapter,
             $searchParams.endChapter,
@@ -107,8 +99,8 @@
         );
     }
 
-    function calculateMaxChapter(bibleBooks: BibleBook[] | null) {
-        return bibleBooks?.find((b) => b.code === bookCode)?.totalChapters ?? 0;
+    function calculateMaxChapter(bibleBooks: BibleBook[]) {
+        return bibleBooks.find((b) => b.code === bookCode)?.totalChapters ?? 0;
     }
 </script>
 
@@ -116,160 +108,154 @@
     <title>Resources | Aquifer Admin</title>
 </svelte:head>
 
-{#await bibleBooksPromise}
-    <CenteredSpinnerFullScreen />
-{:then bibleBooks}
-    <div class="flex h-full flex-col overflow-hidden pt-0 lg:pt-4">
-        <div class="mx-4 text-3xl">{$translate('page.resources.header.value')}</div>
-        <div class="flex flex-shrink-0 flex-row space-x-2 overflow-x-auto px-4 py-2">
-            <Select
-                appInsightsEventName="resources-languages-filter-selection"
-                bind:value={languageId}
-                isNumber={true}
-                class="select select-bordered min-w-[8rem] flex-grow"
-                options={[
-                    { value: 0, label: $translate('page.resources.dropdowns.allLanguages.value') },
-                    ...data.languages.map((l) => ({ value: l.id, label: l.englishDisplay })),
-                ]}
-            />
-            <Select
-                appInsightsEventName="resources-resources-filter-selection"
-                bind:value={parentResourceId}
-                isNumber={true}
-                class="select select-bordered min-w-[10rem] flex-grow"
-                options={[
-                    { value: 0, label: $translate('page.resources.dropdowns.allResources.value') },
-                    ...data.parentResources.map((t) => ({ value: t.id, label: t.displayName })),
-                ]}
-            />
-            <Select
-                appInsightsEventName="resources-book-filter-selection"
-                class="select select-bordered min-w-[9rem] flex-grow"
-                options={[
-                    { value: null, label: 'Select Book' },
-                    ...(bibleBooks || []).map((b) => ({ value: b.code, label: b.localizedName })),
-                ]}
-                onChange={() => (chapterRange = '')}
-                bind:value={bookCode}
-            />
-            <input
-                disabled={!bookCode}
-                bind:value={chapterRange}
-                use:enterKeyHandler={applyFilters}
-                class="input input-bordered input-md w-[11rem]"
-                placeholder="Chapter (e.g. 2, 1-5)"
-            />
-            <div class="flex flex-col space-y-2">
-                <div class="form-control">
-                    <label class="label cursor-pointer py-0">
-                        <span class="label-text text-xs">Published</span>
-                        <input
-                            disabled={!unpublishedChecked}
-                            type="checkbox"
-                            bind:checked={publishedChecked}
-                            class="checkbox no-animation checkbox-sm ms-2"
-                        />
-                    </label>
-                </div>
-                <div class="form-control">
-                    <label class="label cursor-pointer py-0">
-                        <span class="label-text text-xs">Unpublished</span>
-                        <input
-                            disabled={!publishedChecked}
-                            type="checkbox"
-                            bind:checked={unpublishedChecked}
-                            class="checkbox no-animation checkbox-sm ms-2"
-                        />
-                    </label>
-                </div>
+<div class="flex h-full flex-col overflow-hidden pt-0 lg:pt-4">
+    <div class="mx-4 text-3xl">{$translate('page.resources.header.value')}</div>
+    <div class="flex flex-shrink-0 flex-row space-x-2 overflow-x-auto px-4 py-2">
+        <Select
+            appInsightsEventName="resources-languages-filter-selection"
+            bind:value={languageId}
+            isNumber={true}
+            class="select select-bordered min-w-[8rem] flex-grow"
+            options={[
+                { value: 0, label: $translate('page.resources.dropdowns.allLanguages.value') },
+                ...data.languages.map((l) => ({ value: l.id, label: l.englishDisplay })),
+            ]}
+        />
+        <Select
+            appInsightsEventName="resources-resources-filter-selection"
+            bind:value={parentResourceId}
+            isNumber={true}
+            class="select select-bordered min-w-[10rem] flex-grow"
+            options={[
+                { value: 0, label: $translate('page.resources.dropdowns.allResources.value') },
+                ...data.parentResources.map((t) => ({ value: t.id, label: t.displayName })),
+            ]}
+        />
+        <Select
+            appInsightsEventName="resources-book-filter-selection"
+            class="select select-bordered min-w-[9rem] flex-grow"
+            options={[
+                { value: null, label: 'Select Book' },
+                ...(bibleBooks || []).map((b) => ({ value: b.code, label: b.localizedName })),
+            ]}
+            onChange={() => (chapterRange = '')}
+            bind:value={bookCode}
+        />
+        <input
+            disabled={!bookCode}
+            bind:value={chapterRange}
+            use:enterKeyHandler={applyFilters}
+            class="input input-bordered input-md w-[11rem]"
+            placeholder="Chapter (e.g. 2, 1-5)"
+        />
+        <div class="flex flex-col space-y-2">
+            <div class="form-control">
+                <label class="label cursor-pointer py-0">
+                    <span class="label-text text-xs">Published</span>
+                    <input
+                        disabled={!unpublishedChecked}
+                        type="checkbox"
+                        bind:checked={publishedChecked}
+                        class="checkbox no-animation checkbox-sm ms-2"
+                    />
+                </label>
             </div>
-            <input
-                bind:value={searchInputValue}
-                use:enterKeyHandler={applyFilters}
-                class="input input-bordered input-md min-w-[8rem] flex-grow"
-                placeholder={$translate('page.resources.searchBox.value')}
-            />
-            <button class="btn btn-primary" disabled={!canApplyFilters} on:click={applyFilters}>Apply</button>
+            <div class="form-control">
+                <label class="label cursor-pointer py-0">
+                    <span class="label-text text-xs">Unpublished</span>
+                    <input
+                        disabled={!publishedChecked}
+                        type="checkbox"
+                        bind:checked={unpublishedChecked}
+                        class="checkbox no-animation checkbox-sm ms-2"
+                    />
+                </label>
+            </div>
         </div>
+        <input
+            bind:value={searchInputValue}
+            use:enterKeyHandler={applyFilters}
+            class="input input-bordered input-md min-w-[8rem] flex-grow"
+            placeholder={$translate('page.resources.searchBox.value')}
+        />
+        <button class="btn btn-primary" disabled={!canApplyFilters} on:click={applyFilters}>Apply</button>
+    </div>
 
-        {#await resourceContentDataPromise}
-            <CenteredSpinner />
-        {:then resourceContentsOrNull}
-            <div
-                class="mx-4 flex-1 overflow-auto rounded-md border-[1px]
+    {#await resourceContentDataPromise}
+        <CenteredSpinner />
+    {:then resourceContentsOrNull}
+        <div
+            class="mx-4 flex-1 overflow-auto rounded-md border-[1px]
                 {resourceContentsOrNull?.resourceContents.length ? 'rounded-b-none' : 'mb-4'}"
-            >
-                <table class="table table-pin-rows">
-                    <thead>
-                        <tr class="bg-gray-100">
-                            <th class="w-[30%]">{$translate('page.resources.table.nameHeader.value')}</th>
-                            <th class="w-[20%]">{$translate('page.resources.table.typeHeader.value')}</th>
-                            <th class="w-[20%]">{$translate('page.resources.table.languageHeader.value')}</th>
-                            <th class="w-[20%]">{$translate('page.resources.table.statusHeader.value')}</th>
-                            <th class="w-[10%]">{$translate('page.resources.table.publishedHeader.value')}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {#if resourceContentsOrNull}
-                            {#each resourceContentsOrNull.resourceContents as resource (resource.id)}
-                                {@const href = `/resources/${resource.id}`}
-                                <tr class="hover">
-                                    <LinkedTableCell {href}>{resource.englishLabel}</LinkedTableCell>
-                                    <LinkedTableCell {href}>{resource.parentResourceName}</LinkedTableCell>
-                                    <LinkedTableCell {href}>{resource.languageEnglishDisplay}</LinkedTableCell>
-                                    <LinkedTableCell {href}>{resource.status}</LinkedTableCell>
-                                    <LinkedTableCell {href}>{resource.isPublished ? 'Yes' : 'No'}</LinkedTableCell>
-                                </tr>
-                            {:else}
-                                <tr>
-                                    <td colspan="99" class="text-center">No results found.</td>
-                                </tr>
-                            {/each}
+        >
+            <table class="table table-pin-rows">
+                <thead>
+                    <tr class="bg-gray-100">
+                        <th class="w-[30%]">{$translate('page.resources.table.nameHeader.value')}</th>
+                        <th class="w-[20%]">{$translate('page.resources.table.typeHeader.value')}</th>
+                        <th class="w-[20%]">{$translate('page.resources.table.languageHeader.value')}</th>
+                        <th class="w-[20%]">{$translate('page.resources.table.statusHeader.value')}</th>
+                        <th class="w-[10%]">{$translate('page.resources.table.publishedHeader.value')}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#if resourceContentsOrNull}
+                        {#each resourceContentsOrNull.resourceContents as resource (resource.id)}
+                            {@const href = `/resources/${resource.id}`}
+                            <tr class="hover">
+                                <LinkedTableCell {href}>{resource.englishLabel}</LinkedTableCell>
+                                <LinkedTableCell {href}>{resource.parentResourceName}</LinkedTableCell>
+                                <LinkedTableCell {href}>{resource.languageEnglishDisplay}</LinkedTableCell>
+                                <LinkedTableCell {href}>{resource.status}</LinkedTableCell>
+                                <LinkedTableCell {href}>{resource.isPublished ? 'Yes' : 'No'}</LinkedTableCell>
+                            </tr>
                         {:else}
                             <tr>
-                                <td colspan="99" class="text-center">Select filters or Search. Then click "Apply".</td>
+                                <td colspan="99" class="text-center">No results found.</td>
                             </tr>
-                        {/if}
-                    </tbody>
-                </table>
-            </div>
-            {#if resourceContentsOrNull}
-                <div
-                    class="mx-4 mb-2 grid grid-cols-3 rounded-md rounded-t-none border-[1px] border-t-0 bg-base-200 p-2"
+                        {/each}
+                    {:else}
+                        <tr>
+                            <td colspan="99" class="text-center">Select filters or Search. Then click "Apply".</td>
+                        </tr>
+                    {/if}
+                </tbody>
+            </table>
+        </div>
+        {#if resourceContentsOrNull}
+            <div class="mx-4 mb-2 grid grid-cols-3 rounded-md rounded-t-none border-[1px] border-t-0 bg-base-200 p-2">
+                <button
+                    class="btn btn-outline self-center justify-self-start"
+                    class:btn-disabled={$searchParams.page === 1}
+                    on:click={() => ($searchParams.page -= 1)}
+                    >{$translate('page.resources.table.navigation.previous.value')}</button
                 >
-                    <button
-                        class="btn btn-outline self-center justify-self-start"
-                        class:btn-disabled={$searchParams.page === 1}
-                        on:click={() => ($searchParams.page -= 1)}
-                        >{$translate('page.resources.table.navigation.previous.value')}</button
-                    >
-                    <div class="grid place-self-center">
-                        <div class="mb-2">
-                            {$translate('page.resources.table.navigation.pageNumber.value', {
-                                values: {
-                                    currentPage: $searchParams.page,
-                                    totalPages: calculateTotalPages(resourceContentsOrNull.total),
-                                },
-                            })}
-                        </div>
-                        <select bind:value={$resourcesPerPage} class="select select-bordered select-ghost select-xs">
-                            {#each [10, 50, 100] as count, i (i)}
-                                <option value={count} selected={i === 0}>
-                                    {`${count} ${$translate('page.resources.table.navigation.perPage.value')}`}
-                                </option>
-                            {/each}
-                        </select>
+                <div class="grid place-self-center">
+                    <div class="mb-2">
+                        {$translate('page.resources.table.navigation.pageNumber.value', {
+                            values: {
+                                currentPage: $searchParams.page,
+                                totalPages: calculateTotalPages(resourceContentsOrNull.total),
+                            },
+                        })}
                     </div>
-                    <button
-                        class="btn btn-outline self-center justify-self-end"
-                        class:btn-disabled={$searchParams.page === calculateTotalPages(resourceContentsOrNull.total)}
-                        on:click={() => ($searchParams.page += 1)}
-                        >{$translate('page.resources.table.navigation.next.value')}</button
-                    >
+                    <select bind:value={$resourcesPerPage} class="select select-bordered select-ghost select-xs">
+                        {#each [10, 50, 100] as count, i (i)}
+                            <option value={count} selected={i === 0}>
+                                {`${count} ${$translate('page.resources.table.navigation.perPage.value')}`}
+                            </option>
+                        {/each}
+                    </select>
                 </div>
-            {/if}
-        {/await}
-    </div>
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+                <button
+                    class="btn btn-outline self-center justify-self-end"
+                    class:btn-disabled={$searchParams.page === calculateTotalPages(resourceContentsOrNull.total)}
+                    on:click={() => ($searchParams.page += 1)}
+                    >{$translate('page.resources.table.navigation.next.value')}</button
+                >
+            </div>
+        {/if}
+    {:catch error}
+        <ErrorMessage uncastError={error} />
+    {/await}
+</div>

--- a/src/routes/resources/[resourceContentId]/+page.ts
+++ b/src/routes/resources/[resourceContentId]/+page.ts
@@ -1,5 +1,5 @@
 import type { PageLoad } from './$types';
-import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
+import { getFromApi } from '$lib/utils/http-service';
 import type { ResourceContent } from '$lib/types/resources';
 import { userCan, Permission } from '$lib/stores/auth';
 import { redirect } from '@sveltejs/kit';
@@ -13,10 +13,6 @@ export const load: PageLoad = async ({ parent, params, fetch }) => {
     }
 
     return {
-        resourceContentId: params.resourceContentId,
-        resourceContent: getFromApiWithoutBlocking<ResourceContent>(
-            `/resources/content/${params.resourceContentId}`,
-            fetch
-        ),
+        resourceContent: await getFromApi<ResourceContent>(`/resources/content/${params.resourceContentId}`, fetch),
     };
 };

--- a/src/routes/resources/[resourceContentId]/VersionStatusHistorySidebar.svelte
+++ b/src/routes/resources/[resourceContentId]/VersionStatusHistorySidebar.svelte
@@ -1,25 +1,19 @@
-﻿<script lang="ts">
+<script lang="ts">
     import type { VersionStatusHistory } from '$lib/types/resources';
     import CenteredSpinner from '$lib/components/CenteredSpinner.svelte';
-    import { getFromApiWithoutBlocking } from '$lib/utils/http-service';
+    import { getFromApi } from '$lib/utils/http-service';
     import { formatUtcToLocalTimeAndDate } from '$lib/utils/date-time';
 
     export let resourceContentVersionId: number;
     export let visible: boolean;
 
+    let promise: Promise<VersionStatusHistory[] | null> | null = null;
+
     $: if (!promise && visible) {
-        promise = getStatusHistory();
-    }
-
-    let promise: Promise<VersionStatusHistory[]> | null = null;
-
-    async function getStatusHistory() {
-        let statusHistoryEvents = getFromApiWithoutBlocking<VersionStatusHistory[]>(
+        promise = getFromApi<VersionStatusHistory[]>(
             `/resources/content/versions/${resourceContentVersionId}/status-history`,
             fetch
         );
-
-        return statusHistoryEvents.promise;
     }
 </script>
 

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -2,29 +2,26 @@
     import type { PageData } from './$types';
     import { _ as translate } from 'svelte-i18n';
     import NewUserModal from '$lib/components/users/NewUserModal.svelte';
-    import { type Company, type User, UserRole } from '$lib/types/base';
+    import { type User, UserRole } from '$lib/types/base';
     import { Permission, userCan, userIsEqual } from '$lib/stores/auth';
     import Select from '$lib/components/Select.svelte';
     import Modal from '$lib/components/Modal.svelte';
     import PersonDashIcon from '$lib/icons/PersonDashIcon.svelte';
     import { patchToApi } from '$lib/utils/http-service';
     import { createIsPageTransactingContext } from '$lib/context/is-page-transacting-context';
-    import CenteredSpinnerFullScreen from '$lib/components/CenteredSpinnerFullScreen.svelte';
-    import ErrorMessage from '$lib/components/ErrorMessage.svelte';
 
     export let data: PageData;
 
     const isPageTransacting = createIsPageTransactingContext();
-    let userData: User[];
-    let companies: Company[];
     let filterBySearch: string | null = null;
     let filterByCompanyId: number | null = null;
     let isDisableUserModalOpen = false;
     let isShowingErrorModal = false;
+    let isModalOpen = false;
 
-    const loadContents = async () => {
-        [userData, companies] = await Promise.all([data.userData!.promise, data.companies!.promise]);
-    };
+    $: users = data.users;
+    $: companies = data.companies;
+    $: roles = data.roles;
 
     const filterUsers = (users: User[], search: string | null, companyId: number | null) => {
         return users.filter(
@@ -37,14 +34,14 @@
     let onConfirmDisableUser: (() => Promise<void>) | undefined = undefined;
     const disableUser = (userId: number) => {
         isDisableUserModalOpen = true;
-        onConfirmDisableUser = async () => postDisableUser(userId);
+        onConfirmDisableUser = async () => await postDisableUser(userId);
     };
 
     const postDisableUser = async (userId: number) => {
         try {
             $isPageTransacting = true;
             await patchToApi(`/users/${userId}/disable`);
-            userData = userData.filter((x) => x.id !== userId);
+            users = users.filter((x) => x.id !== userId);
         } catch (e) {
             isShowingErrorModal = true;
         } finally {
@@ -55,10 +52,7 @@
         }
     };
 
-    $: isModalOpen = false;
-    $: roles = data.roles!;
-
-    async function openModal() {
+    function openModal() {
         isModalOpen = true;
     }
 </script>
@@ -67,88 +61,82 @@
     <title>Users | Aquifer Admin</title>
 </svelte:head>
 
-{#await loadContents()}
-    <CenteredSpinnerFullScreen />
-{:then _}
-    <div class="flex flex-col overflow-y-hidden px-4">
-        <div class="my-4">
-            <div class="text-3xl">{$translate('page.users.header.value')}</div>
-        </div>
-        <div class="flex justify-between">
-            <div class="flex w-1/2 space-x-8">
-                {#if $userCan(Permission.ReadAllUsers)}
-                    <Select
-                        class="select select-bordered max-w-xs"
-                        options={[
-                            { value: null, label: 'Select Company' },
-                            ...companies.map((c) => ({ value: c.id, label: c.name })),
-                        ]}
-                        isNumber={true}
-                        bind:value={filterByCompanyId}
-                    />
-                {/if}
-                <input
-                    bind:value={filterBySearch}
-                    type="search"
-                    class="min-h-12 w-[320px] rounded-md border-[1px] py-2 ps-5 text-sm text-gray-900 focus:outline-none"
-                    placeholder={$translate('page.resources.searchBox.value')}
+<div class="flex flex-col overflow-y-hidden px-4">
+    <div class="my-4">
+        <div class="text-3xl">{$translate('page.users.header.value')}</div>
+    </div>
+    <div class="flex justify-between">
+        <div class="flex w-1/2 space-x-8">
+            {#if $userCan(Permission.ReadAllUsers)}
+                <Select
+                    class="select select-bordered max-w-xs"
+                    options={[
+                        { value: null, label: 'Select Company' },
+                        ...companies.map((c) => ({ value: c.id, label: c.name })),
+                    ]}
+                    isNumber={true}
+                    bind:value={filterByCompanyId}
                 />
-                <button class="btn btn-primary" on:click={openModal}>Add</button>
-            </div>
-        </div>
-        <div class="flex flex-row space-x-4 overflow-y-hidden">
-            <div class="my-4 max-h-full flex-[2] overflow-y-auto rounded border-2">
-                <table class="table table-pin-rows">
-                    <thead>
-                        <tr class="bg-base-200">
-                            <th>{$translate('page.users.name.value')}</th>
-                            <th>{$translate('page.users.email.value')}</th>
-                            <th>{$translate('page.users.role.value')}</th>
-                            <th>{$translate('page.users.company.value')}</th>
-                            <th>{$translate('page.users.status.value')}</th>
-                            <th />
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {#each filterUsers(userData, filterBySearch, filterByCompanyId) as user (user.email)}
-                            <tr class="text-xs">
-                                <td class="px-5">{user.name}</td>
-                                <td class="px-5">{user.email}</td>
-                                <td class="px-5">{user.role}</td>
-                                <td class="px-5">{user.company.name}</td>
-                                <td class="px-5">{user.isEmailVerified ? 'Verified' : 'Invited'}</td>
-                                <td class="px-5 text-primary">
-                                    {#if user.role !== UserRole.Publisher && user.role !== UserRole.Admin && !$userIsEqual(user.id)}
-                                        <button
-                                            data-app-insights-event-name="disable-user-button-click"
-                                            class="btn btn-circle btn-link btn-xs"
-                                            on:click={() => disableUser(user.id)}
-                                            ><PersonDashIcon />
-                                        </button>
-                                    {/if}
-                                </td>
-                            </tr>
-                        {/each}
-                    </tbody>
-                </table>
-            </div>
+            {/if}
+            <input
+                bind:value={filterBySearch}
+                type="search"
+                class="min-h-12 w-[320px] rounded-md border-[1px] py-2 ps-5 text-sm text-gray-900 focus:outline-none"
+                placeholder={$translate('page.resources.searchBox.value')}
+            />
+            <button class="btn btn-primary" on:click={openModal}>Add</button>
         </div>
     </div>
-    <NewUserModal {companies} {roles} header="Add User" bind:open={isModalOpen} />
-    <Modal
-        header="Confirm Disable User"
-        bind:open={isDisableUserModalOpen}
-        description="This user will be disabled"
-        primaryButtonText="Disable User"
-        primaryButtonOnClick={onConfirmDisableUser}
-        isTransacting={$isPageTransacting}
-    />
-    <Modal
-        isError={true}
-        header="Error disabling user"
-        description="An error occurred disabling the user. Please try again later."
-        bind:open={isShowingErrorModal}
-    />
-{:catch error}
-    <ErrorMessage uncastError={error} />
-{/await}
+    <div class="flex flex-row space-x-4 overflow-y-hidden">
+        <div class="my-4 max-h-full flex-[2] overflow-y-auto rounded border-2">
+            <table class="table table-pin-rows">
+                <thead>
+                    <tr class="bg-base-200">
+                        <th>{$translate('page.users.name.value')}</th>
+                        <th>{$translate('page.users.email.value')}</th>
+                        <th>{$translate('page.users.role.value')}</th>
+                        <th>{$translate('page.users.company.value')}</th>
+                        <th>{$translate('page.users.status.value')}</th>
+                        <th />
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each filterUsers(users, filterBySearch, filterByCompanyId) as user (user.email)}
+                        <tr class="text-xs">
+                            <td class="px-5">{user.name}</td>
+                            <td class="px-5">{user.email}</td>
+                            <td class="px-5">{user.role}</td>
+                            <td class="px-5">{user.company.name}</td>
+                            <td class="px-5">{user.isEmailVerified ? 'Verified' : 'Invited'}</td>
+                            <td class="px-5 text-primary">
+                                {#if user.role !== UserRole.Publisher && user.role !== UserRole.Admin && !$userIsEqual(user.id)}
+                                    <button
+                                        data-app-insights-event-name="disable-user-button-click"
+                                        class="btn btn-circle btn-link btn-xs"
+                                        on:click={() => disableUser(user.id)}
+                                        ><PersonDashIcon />
+                                    </button>
+                                {/if}
+                            </td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<NewUserModal {companies} {roles} header="Add User" bind:open={isModalOpen} />
+<Modal
+    header="Confirm Disable User"
+    bind:open={isDisableUserModalOpen}
+    description="This user will be disabled"
+    primaryButtonText="Disable User"
+    primaryButtonOnClick={onConfirmDisableUser}
+    isTransacting={$isPageTransacting}
+/>
+<Modal
+    isError={true}
+    header="Error disabling user"
+    description="An error occurred disabling the user. Please try again later."
+    bind:open={isShowingErrorModal}
+/>


### PR DESCRIPTION
Initially, due to using SSR, our API calls were mostly wrapped with a `{ promise: ... }` object using the `getFromApiWithoutBlocking` function. This helped the pages feel like they loaded a bit more snappy when SSR was turned on and we could have a spinner/skeleton on any part of the page.

However, we were only really taking advantage of the spinner/skeleton in two places, and we dropped SSR support a while back. Because of this, we can simplify the API calls a lot and avoid a bunch of async/await code by making the requests blocking again.

It's also worth pointing out that "blocking" in this case means that the centered spinner shows up in the middle of the page while data is being fetched. Previously with the SSR approach we would get a white page with "blocking" loading, but now the HTML is there so we have a centered spinner.

As a byproduct of doing more blocking calls in the `load` functions, the error handling needed to be adjusted. It ended up being a simpler approach and less boilerplatey, with a `errorGotoPath` global store that can be set in a page's `load` function to indicate 404 redirect behavior. Most other error handling is now done automatically through the `+error.svelte` component.