### PR TITLE
add build-with-source-maps script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "dev": "vite dev",
         "build": "vite build",
+        "build-with-source-maps": "INCLUDE_SOURCE_MAPS=true vite build",
         "preview": "vite preview",
         "test": "vitest",
         "lint:unused-translations": "run-script-os",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
         port: 5273,
         strictPort: false,
     },
+    build: {
+        sourcemap: process.env.INCLUDE_SOURCE_MAPS === 'true',
+    },
     test: {
         globals: true,
         environment: 'jsdom',


### PR DESCRIPTION
This gets used by the `aquifer-utilities` `get-app-insights-js-error-context.js` script to show errors that tie to the source map.