### PR TITLE
Update tsconfig.json to fix import error for new `*.svelte.ts` files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "./.svelte-kit/tsconfig.json",
     "compilerOptions": {
         "allowJs": true,
+        "allowImportingTsExtensions": true,
         "checkJs": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Resolv the TS error: `An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.ts(5097)` when using the new `*.svelte.ts` extension in an import