### PR TITLE
BIB-811 - Resolving Missing Bible For Language Bug

### DIFF
--- a/src/routes/resources/[resourceContentId]/BibleReferencesSidebar.svelte
+++ b/src/routes/resources/[resourceContentId]/BibleReferencesSidebar.svelte
@@ -45,7 +45,11 @@
             bibles = await fetchLanguageBiblesAndEnglishDefault(language.id);
             fetchedBibles = true;
         }
-        const bible = bibles.find((b) => b.languageId === language.id && b.isLanguageDefault);
+
+        const bible = bibles.some((b) => b.languageId === language.id && b.isLanguageDefault)
+            ? bibles.find((b) => b.languageId === language.id && b.isLanguageDefault)
+            : bibles.find((b) => b.languageId === 1 && b.isLanguageDefault);
+
         if (currentBibleId === null) {
             currentBibleId = bible?.id ?? null;
         }


### PR DESCRIPTION
This bug was found while testing BIB-811 in QA. The following [resource](https://qa.admin.aquifer.bible/resources/49976) in Portuguese does not have a default bible for its language. It is supposed to fallback to BSB and does, but the new dropdown does not display BSB. 

![Screenshot 2025-01-20 at 4 02 47 PM](https://github.com/user-attachments/assets/91185d1e-36fb-43d0-b45e-7273b0eaa4e8)

This PR fixes that issue. 