### PR TITLE
Update ResizeObserver to use requestAnimationFrame

### DIFF
--- a/src/lib/components/editor/EditorToolbar.svelte
+++ b/src/lib/components/editor/EditorToolbar.svelte
@@ -194,7 +194,9 @@
     onMount(() => {
         if (outerDiv) {
             resizeObserver = new ResizeObserver(() => {
-                outerDivWidth = outerDiv?.offsetWidth ?? null;
+                requestAnimationFrame(() => {
+                    outerDivWidth = outerDiv?.offsetWidth ?? null;
+                });
             });
             resizeObserver.observe(outerDiv);
 


### PR DESCRIPTION
This bug is the result of wanting the editor controls to be rendered in a dropdown when the editor becomes too narrow to display all of the icons.
![Screenshot 2025-01-24 at 2 27 49 PM](https://github.com/user-attachments/assets/55c94c45-f9b6-4a87-87ec-93f1e116cfe8)

VS
![Screenshot 2025-01-24 at 2 28 07 PM](https://github.com/user-attachments/assets/f0310fb9-75cf-4267-b7ed-8f8ccbbed7a2)

The `ResizeObserver` is used to observe elements on the page rather than the entire document. Exactly what we want.

However, this is incredibly hard to reproduce. I was not able to reproduce it using multiple browsers and throttling on both the network and the CPU. Insight logs show this error affecting Chrome and Edge with resources of varying lengths.

According to posts on Stackoverflow and [MDN](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors), the solution is to add a `debounce` or `requestAnimationFrame` to your `ResizeObserver`.

So, I added the `requestAnimationFrame` to the ResizeObserver.