### PR TITLE
Bib 844 for community reviewers only show helpful how to documents

### DIFF
--- a/src/lib/components/help/Document.svelte
+++ b/src/lib/components/help/Document.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <a href={document.url} target="_blank" class="overflow flex w-40 flex-col items-center hover:text-primary">
-    <span class="w-16">
+    <span class="h-20 w-16">
         {#if document.thumbnailUrl}
             <img src={document.thumbnailUrl} alt={document.title} class="h-full w-full object-contain" />
         {:else if document.type === HelpDocumentType.HowTo}

--- a/src/routes/(dashboard)/+page.ts
+++ b/src/routes/(dashboard)/+page.ts
@@ -6,6 +6,7 @@ import type { BibleBook, ResourceContentStatusEnum } from '$lib/types/base';
 import { redirect } from '@sveltejs/kit';
 import type { ProjectResourceStatusCounts } from '$lib/types/projects';
 import type { ResourceContentVersionReviewLevel } from '$lib/types/resources';
+import type { HelpDocumentResponse } from '$lib/types/helpDocuments';
 
 export const load: PageLoad = async ({ parent, fetch }) => {
     await parent();
@@ -45,13 +46,21 @@ export const load: PageLoad = async ({ parent, fetch }) => {
             },
         };
     } else if (get(userCan)(Permission.CreateCommunityContent)) {
-        const [assignedResourceContent, assignedResourceHistoryContent, bibleBooks] = await Promise.all([
+        const [assignedResourceContent, assignedResourceHistoryContent, bibleBooks, helpDocs] = await Promise.all([
             fetchAssignedResourceContent(fetch),
             getFromApi<ResourceAssignedToSelfHistory[]>('/resources/content/assigned-to-self/history', fetch),
             getFromApi<BibleBook[]>('/bibles/1/books', fetch),
+            getFromApi<HelpDocumentResponse>('/help/aquifer-cms/documents', fetch),
         ]);
 
-        return { communityReviewerDashboard: { assignedResourceContent, assignedResourceHistoryContent, bibleBooks } };
+        return {
+            communityReviewerDashboard: {
+                assignedResourceContent,
+                assignedResourceHistoryContent,
+                bibleBooks,
+                helpDocs,
+            },
+        };
     } else if (get(userCan)(Permission.EditContent)) {
         const [assignedResourceContent, assignedResourceHistoryContent] = await Promise.all([
             fetchAssignedResourceContent(fetch),
@@ -73,6 +82,7 @@ function fetchAssignedResourceContent(injectedFetch: typeof window.fetch) {
 export enum _CommunityReviewerTab {
     resources = 'resources',
     myHistory = 'my-history',
+    help = 'help',
 }
 
 export enum _PublisherTab {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -205,16 +205,18 @@
                 </ul>
             </div>
             <div class="m-2 w-16"><a href="/"><img src={AquiferLogo} alt="Aquifer" /></a></div>
-            <div class="ml-auto">
-                <Tooltip position={{ right: '3rem', top: '0.25rem' }} class="ml-auto" text="Help">
-                    <a
-                        href="/help"
-                        class="btn btn-neutral btn-xs m-1 border border-neutral-300 hover:border-primary hover:text-primary"
-                    >
-                        <QuestionMarkIcon />
-                    </a>
-                </Tooltip>
-            </div>
+            {#if !$userCan(Permission.CreateCommunityContent)}
+                <div class="ml-auto">
+                    <Tooltip position={{ right: '3rem', top: '0.25rem' }} class="ml-auto" text="Help">
+                        <a
+                            href="/help"
+                            class="btn btn-neutral btn-xs m-1 border border-neutral-300 hover:border-primary hover:text-primary"
+                        >
+                            <QuestionMarkIcon />
+                        </a>
+                    </Tooltip>
+                </div>
+            {/if}
         </div>
 
         {#if $navigating && !isCustomTransitionNavigation($navigating)}


### PR DESCRIPTION
Most of the Help content does not apply to Community Users. So, this ticket has us implementing a `Help` tab on their Dashboard. 

I used a `localstorage` flag to simulate a 'first login' check. If they clear the storage in their browser, the disruption is minimal and this prevents us from having to build out a backend solution for login tracking.