### PR TITLE
Bugfix Unsafe mutation

### DIFF
--- a/src/lib/components/editor/TiptapRenderer.svelte
+++ b/src/lib/components/editor/TiptapRenderer.svelte
@@ -1,4 +1,4 @@
-﻿<script lang="ts">
+<script lang="ts">
     import { onMount, onDestroy } from 'svelte';
     import { Editor } from 'aquifer-tiptap';
     import type { TiptapContentItem } from '$lib/types/resources';
@@ -92,7 +92,10 @@
     });
 
     onDestroy(() => {
-        $editor?.destroy();
+        if ($editor && !$editor.isDestroyed) {
+            $editor.off('transaction');
+            $editor.destroy();
+        }
     });
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -222,7 +222,7 @@
         {#if $navigating && !isCustomTransitionNavigation($navigating)}
             <CenteredSpinnerFullScreen />
         {:else}
-            <div class="relative flex h-full max-h-[calc(100vh-39px)] w-full flex-col">
+            <div class="relative flex h-full max-h-[calc(100vh-39px)] w-full flex-col overflow-hidden">
                 {@render children()}
             </div>
         {/if}

--- a/src/routes/resources/[resourceContentId]/+page.svelte
+++ b/src/routes/resources/[resourceContentId]/+page.svelte
@@ -717,9 +717,10 @@
 {#key resourceContent.resourceContentId}
     <div
         onintroend={() => (shouldTransition = false)}
-        in:fly={{ x: '100%', duration: shouldTransition ? 450 : 0, delay: shouldTransition ? 350 : 0 }}
-        out:fly={{ x: '-100%', duration: shouldTransition ? 450 : 0, delay: shouldTransition ? 250 : 0 }}
-        class="px-8 pt-1"
+        in:fly={{ x: 500, duration: shouldTransition ? 450 : 0, delay: shouldTransition ? 350 : 0 }}
+        out:fly={{ x: -500, duration: shouldTransition ? 450 : 0, delay: shouldTransition ? 250 : 0 }}
+        class="w-screen px-8 pt-1"
+        class:absolute={shouldTransition}
     >
         <div class="flex w-full items-center justify-between border-b-[1px]">
             <div class="me-2 flex place-items-center">


### PR DESCRIPTION
The unsafe mutation was caused by a race condition where the editor had pending transaction events when the next animation frame was called. This resulted in the ownership of `editor` being different from the one that the transaction was called from when the value was `set`. 