### PR TITLE
Fix rtl verses to display correctly in popup and sidebar

### DIFF
--- a/src/lib/utils/reference.ts
+++ b/src/lib/utils/reference.ts
@@ -33,7 +33,10 @@ export function generateVerseFromReference(
     // like Arabic. It makes sure that a reference like Luke 12:17 shows up as 17:12 Luke instead of 12:17 Luke.
     // It inserts tiny spaces into the content that are almost invisible to humans but the RTL browser handling
     // notices it and formats things correctly.
-    const rtlSpace = scriptDirection === ScriptDirection.RTL ? tinySpace : '';
+    const rtlDirection = ScriptDirection.RTL.toString().toUpperCase(); // enum comparison don't work in current version of svelte5
+    const direction = scriptDirection.toString().toUpperCase();
+
+    const rtlSpace = direction === rtlDirection ? tinySpace : '';
 
     let label: string;
     if (instanceOfPassageReference(reference)) {


### PR DESCRIPTION
Svelte5 doesn't consistently work when comparing enums:
https://github.com/sveltejs/svelte/issues/11502

Solution" Convert them explicitly to upper-case strings first, then compare

Also looked into doing preprocess with vite for typescript, but it's already set to `script`, and it doesn't work doing both. Also, syntax breaks to preprocess with only `typescript` and not `script`. I also don't think it's worth doing something that affects server-level when the solution above fixes it.

