### PR TITLE
Fixing Page Miss Match Bug

### DIFF
--- a/src/lib/components/Table.svelte
+++ b/src/lib/components/Table.svelte
@@ -123,6 +123,12 @@
         scrollingDiv && items && checkScrollable();
     });
 
+    $effect(() => {
+        if (showingPaginator && currentPage && totalPages && currentPage > totalPages) {
+            currentPage = 1;
+        }
+    });
+
     function calculateScrollShadows({
         isRightScrollable,
         isLeftScrollable,


### PR DESCRIPTION
Since more tables are being paginated and pages with as many as 1000 items are available, this patch kicks the user back to page one if the user's current page is more significant than the available pages. This happens if a user has a table with 600 items and 100 items per page. If the user navigates to page 3 and then switches the total number of items to 1000, the user sees no items, and the pages are wrong. 

Image of bug:
![Screenshot 2025-03-04 at 4 10 04 PM](https://github.com/user-attachments/assets/a00a7b02-e5a1-4527-96e9-20d3ab5fe051)
