### PR TITLE
Fixing All Items Selected In Drop Down Bug

### DIFF
--- a/src/lib/components/Table.svelte
+++ b/src/lib/components/Table.svelte
@@ -123,8 +123,8 @@
         scrollingDiv && items && checkScrollable();
     });
 
-    $effect(() => {
-        if (showingPaginator && currentPage && totalPages && currentPage > totalPages) {
+    $effect.pre(() => {
+        if (itemsPerPage === Infinity || (showingPaginator && currentPage && totalPages && currentPage > totalPages)) {
             currentPage = 1;
         }
     });


### PR DESCRIPTION
Users were not getting kicked back to page one if they selected "all" in the dropdown of paginated tables. Also added "pre" to the effect to avoid jumpy UI. 