### PR TITLE
Handle multiple target verse mappings and correctly display verse 0.

### DIFF
--- a/src/lib/components/references/BibleTextReference.svelte
+++ b/src/lib/components/references/BibleTextReference.svelte
@@ -50,7 +50,14 @@
                     <div class="font-semibold" dir="auto">Chapter {chapter.number}</div>
                 {/if}
                 {#each chapter.verses as verse (verse)}
-                    <div dir="auto"><sup class="font-bold">{verse.number}</sup> {verse.text}</div>
+                    <div dir="auto">
+                        {#if verse.number === 0}
+                            <span class="italic">{verse.text}</span>
+                        {:else}
+                            <sup class="font-bold">{verse.number}</sup>
+                            {verse.text}
+                        {/if}
+                    </div>
                 {/each}
             {/each}
         {/each}

--- a/src/lib/components/references/bibleTextReferenceFetcher.ts
+++ b/src/lib/components/references/bibleTextReferenceFetcher.ts
@@ -19,6 +19,11 @@ export const fetchAndFormat = async (
     language: Language,
     passedBibleId?: number
 ): Promise<BibleTextsReference | null> => {
+    // ensure we always include verse 0 along with verse 1 if verse 0 exists
+    if (startVerse % 1000 === 1) {
+        startVerse -= 1;
+    }
+
     const [bookTexts, versificationMappings] = await Promise.all([
         fetchBiblePassages(startVerse, endVerse, language.id, passedBibleId),
         fetchBibleVersification(startVerse, endVerse, language.id, passedBibleId),
@@ -120,22 +125,11 @@ export const fetchAndFormat = async (
                 }
             }
 
-            const parsedStartVerse = parseVerseId(passageStartVerseId);
-            const parsedEndVerse = parseVerseId(passageEndVerseId);
-
             // does passage exist in current bookTexts?
             passageBookTexts = getMultiVersePassageContentFromBookTexts(
                 bookTexts,
-                {
-                    bookId: parsedStartVerse.bookId,
-                    chapter: parsedStartVerse.chapter,
-                    verse: parsedStartVerse.verse,
-                },
-                {
-                    bookId: parsedEndVerse.bookId,
-                    chapter: parsedEndVerse.chapter,
-                    verse: parsedEndVerse.verse,
-                }
+                parseVerseId(passageStartVerseId),
+                parseVerseId(passageEndVerseId)
             );
 
             // if not, fetch passage content according to new start and end and set as bookTexts

--- a/src/lib/components/references/bibleTextReferenceFetcher.ts
+++ b/src/lib/components/references/bibleTextReferenceFetcher.ts
@@ -43,39 +43,41 @@ export const fetchAndFormat = async (
     const parsedStartVerse = parseVerseId(startVerse);
     const parsedEndVerse = hasMultipleVerses ? parseVerseId(endVerse) : null;
 
+    // This logic assumes that all returned mappings are an exact range in the target Bible.  This is not necessarily true but is easier to reason about.
+    // In the future we may need to update this logic to handle more complex mappings if real-world scenarios arise where mappings are non-consecutive verses.
     if (passageHasDifferentBaseMappings) {
         if (!hasMultipleVerses) {
             // if passage is single verse and we have base mapping, startVerseMapping will always be defined
             //! startVerseMapping.targetVerse can be null.
-            //! This represents an exclusion = verse does not exist in target bible
+            //! This represents an exclusion = verse does not exist in target Bible
             const startVerseMapping = findMappingByVerseId(startVerse, versificationMappings);
-            if (startVerseMapping!.targetVerse === null) {
+            if (startVerseMapping!.targetVerses === null || startVerseMapping!.targetVerses.length === 0) {
                 // handle exclusion
                 return null;
             }
 
             // does mapping exist in bookTexts?
-            passageBookTexts = getSingleVersePassageContentFromBookTexts(bookTexts, {
-                bookId: parseVerseId(startVerseMapping!.targetVerse.verseId).bookId,
-                chapter: startVerseMapping!.targetVerse.chapter,
-                verse: startVerseMapping!.targetVerse.verse,
-            });
+            passageBookTexts = getMultiVersePassageContentFromBookTexts(
+                bookTexts,
+                parseVerseId(startVerseMapping!.targetVerses[0]!.verseId),
+                parseVerseId(startVerseMapping!.targetVerses.at(-1)!.verseId)
+            );
 
             if (passageBookTexts.length === 0) {
                 //  if not, fetch according to mapping and set as bookTexts
                 try {
                     passageBookTexts = await fetchBiblePassages(
-                        startVerseMapping!.targetVerse.verseId,
-                        startVerseMapping!.targetVerse.verseId,
+                        startVerseMapping!.targetVerses[0]!.verseId,
+                        startVerseMapping!.targetVerses.at(-1)!.verseId,
                         language.id,
                         passedBibleId
                     );
                 } catch (error) {
                     log.exception(
                         new Error(
-                            `Error fetching mapped verses content - VerseId: ${
-                                startVerseMapping!.targetVerse.verseId
-                            } - Error: ${error}`
+                            `Error fetching mapped verses content - StartVerseId: ${
+                                startVerseMapping!.targetVerses[0]!.verseId
+                            } - EndVerseId: ${startVerseMapping!.targetVerses.at(-1)!.verseId} - Error: ${error}`
                         )
                     );
                     return null;
@@ -101,27 +103,27 @@ export const fetchAndFormat = async (
             let passageEndVerseId = endVerse;
 
             if (startVerseMapping) {
-                if (startVerseMapping.targetVerse === null) {
+                if (startVerseMapping.targetVerses === null || startVerseMapping.targetVerses.length === 0) {
                     // exclusion - this passage, or part of it, does not exist in target bible
                     return null;
                 } else {
-                    passageStartVerseId = startVerseMapping.targetVerse.verseId;
+                    passageStartVerseId = startVerseMapping.targetVerses[0]!.verseId;
                 }
             }
 
             if (endVerseMapping) {
-                if (endVerseMapping.targetVerse === null) {
+                if (endVerseMapping.targetVerses === null || endVerseMapping.targetVerses.length === 0) {
                     // exclusion - this passage, or part of it, does not exist in target bible
                     return null;
                 } else {
-                    passageEndVerseId = endVerseMapping.targetVerse.verseId;
+                    passageEndVerseId = endVerseMapping.targetVerses.at(-1)!.verseId;
                 }
             }
 
             const parsedStartVerse = parseVerseId(passageStartVerseId);
             const parsedEndVerse = parseVerseId(passageEndVerseId);
 
-            // does pasage exist in current bookTexts?
+            // does passage exist in current bookTexts?
             passageBookTexts = getMultiVersePassageContentFromBookTexts(
                 bookTexts,
                 {

--- a/src/lib/utils/bible-versification-fetcher.ts
+++ b/src/lib/utils/bible-versification-fetcher.ts
@@ -10,7 +10,7 @@ export interface VersificationResponse {
 
 export interface VerseMapping {
     sourceVerse: VerseReference;
-    targetVerse: VerseReference;
+    targetVerses: VerseReference[];
 }
 
 // returns null if an error occurs, [] if no mappings are found (passage perfectly aligned)

--- a/src/lib/utils/reference.ts
+++ b/src/lib/utils/reference.ts
@@ -41,14 +41,16 @@ export function generateVerseFromReference(
 
     let label: string;
     if (instanceOfPassageReference(reference)) {
+        // don't include verse 0 when displaying references
+        const startVerse = reference.startVerse === 0 ? 1 : reference.startVerse;
         if (reference.startBook === reference.endBook) {
             if (reference.startChapter === reference.endChapter) {
-                label = `${reference.startBook} ${reference.startChapter}${rtlSpace}:${rtlSpace}${reference.startVerse}-${reference.endVerse}`;
+                label = `${reference.startBook} ${reference.startChapter}${rtlSpace}:${rtlSpace}${startVerse}-${reference.endVerse}`;
             } else {
-                label = `${reference.startBook} ${reference.startChapter}${rtlSpace}:${rtlSpace}${reference.startVerse}-${reference.endChapter}${rtlSpace}:${rtlSpace}${reference.endVerse}`;
+                label = `${reference.startBook} ${reference.startChapter}${rtlSpace}:${rtlSpace}${startVerse}-${reference.endChapter}${rtlSpace}:${rtlSpace}${reference.endVerse}`;
             }
         } else {
-            label = `${reference.startBook} ${reference.startChapter}${rtlSpace}:${rtlSpace}${reference.startVerse} - ${reference.endBook} ${reference.endChapter}${rtlSpace}:${rtlSpace}${reference.endVerse}`;
+            label = `${reference.startBook} ${reference.startChapter}${rtlSpace}:${rtlSpace}${startVerse} - ${reference.endBook} ${reference.endChapter}${rtlSpace}:${rtlSpace}${reference.endVerse}`;
         }
     } else {
         label = `${reference.book} ${reference.chapter}${rtlSpace}:${rtlSpace}${reference.verse}`;


### PR DESCRIPTION
Handles the breaking change in [aquifer-server](https://github.com/BiblioNexusStudio/aquifer-server/pull/722) which returns versification mappings with multiple target verses for a single source verse.

Resources for testing:
* Psalm 3: https://qa.admin.aquifer.bible/resources/41072 (English with verse 0 data)
* Psalm 3: https://qa.admin.aquifer.bible/resources/385014 (Russian mapping with a verse 1 superscript shift and thus a higher max verse number than English)
* Psalm 11: https://qa.admin.aquifer.bible/resources/40541 (English with verse 0 data)
* Psalm 11: https://qa.admin.aquifer.bible/resources/385015 (Russian mapping to a different chapter as well as a combined verse 1 superscript and text and thus the same max verse number as English)

Working verse 0 display as superscript:
![image](https://github.com/user-attachments/assets/d0b56442-ff27-4b83-894a-240d9a2c32b8)

Working Russian mapping:
![image](https://github.com/user-attachments/assets/38f89d83-23a6-4aad-b269-da625e8e6b13)
