### PR TITLE
Fix verse reference display.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ yarn-error.log
 __azurite*
 __blobstorage*
 __queuestorage*
+
+# Visual Studio Code files
+.vscode/

--- a/src/lib/components/references/bibleTextReferenceFetcher.ts
+++ b/src/lib/components/references/bibleTextReferenceFetcher.ts
@@ -95,12 +95,9 @@ export const fetchAndFormat = async (
                 }
             }
 
-            verseDisplayName =
-                startVerseMapping!.targetVerses.length === 1
-                    ? generateSingleVerseDisplayName(passageBookTexts, language, true)
-                    : generateVerseRangeDisplayName(passageBookTexts, language, true);
+            verseDisplayName = generateVerseReference(passageBookTexts, language, true);
         } else {
-            // multiple vers passage with at least some mappings
+            // multiple verse passage with at least some mappings
             // ! any given VerseMapping.targetVerse in the mapping can be null.
             // ! This represents an exclusion = verse does not exist in target bible
 
@@ -162,10 +159,7 @@ export const fetchAndFormat = async (
                 }
             }
 
-            verseDisplayName =
-                passageStartVerseId === passageEndVerseId
-                    ? generateSingleVerseDisplayName(passageBookTexts, language, true)
-                    : generateVerseRangeDisplayName(passageBookTexts, language, true);
+            verseDisplayName = generateVerseReference(passageBookTexts, language, true);
         }
     } else {
         // if passage has no mapping, passage perfectly aligned
@@ -177,7 +171,7 @@ export const fetchAndFormat = async (
                 return null;
             }
 
-            verseDisplayName = generateSingleVerseDisplayName(passageBookTexts, language, false);
+            verseDisplayName = generateVerseReference(passageBookTexts, language, false);
         } else {
             passageBookTexts = getMultiVersePassageContentFromBookTexts(bookTexts, parsedStartVerse, parsedEndVerse!);
 
@@ -187,10 +181,7 @@ export const fetchAndFormat = async (
             }
 
             // handle the case where verse 0 was requested in addition to only requesting verse 1 but verse 0 doesn't exist in the target Bible
-            verseDisplayName =
-                passageBookTexts.length === 1
-                    ? generateSingleVerseDisplayName(passageBookTexts, language, false)
-                    : generateVerseRangeDisplayName(passageBookTexts, language, false);
+            verseDisplayName = generateVerseReference(passageBookTexts, language, false);
         }
     }
 
@@ -285,46 +276,42 @@ function getMultiVersePassageContentFromBookTexts(
     return passageContent;
 }
 
-function generateSingleVerseDisplayName(
-    bookTexts: BibleBookTexts[],
-    language: Language,
-    hasDifferentMapping: boolean
-): string {
-    const singleBookText = bookTexts[0]!;
-    const singleChapter = singleBookText.chapters[0]!;
-    const singleVerse = singleChapter.verses[0]!;
+function generateVerseReference(bookTexts: BibleBookTexts[], language: Language, hasDifferentMapping: boolean): string {
+    if (
+        bookTexts.length === 1 &&
+        bookTexts[0]!.chapters.length === 1 &&
+        bookTexts[0]!.chapters[0]!.verses.length === 1
+    ) {
+        const singleBookText = bookTexts[0]!;
+        const singleChapter = singleBookText.chapters[0]!;
+        const singleVerse = singleChapter.verses[0]!;
 
-    return generateVerseFromReference(
-        {
-            verseId: 0,
-            book: singleBookText.bookName,
-            chapter: singleChapter.number,
-            verse: singleVerse.number,
-        },
-        language.scriptDirection,
-        hasDifferentMapping
-    );
-}
-
-function generateVerseRangeDisplayName(
-    bookTexts: BibleBookTexts[],
-    language: Language,
-    hasDifferentMapping: boolean
-): string {
-    return generateVerseFromReference(
-        {
-            startVerseId: 0,
-            startBook: bookTexts[0]!.bookName,
-            startChapter: bookTexts[0]!.chapters[0]!.number,
-            startVerse: bookTexts[0]!.chapters[0]!.verses[0]!.number,
-            endVerseId: 0,
-            endBook: bookTexts.at(-1)!.bookName,
-            endChapter: bookTexts.at(-1)!.chapters.at(-1)!.number,
-            endVerse: bookTexts.at(-1)!.chapters.at(-1)!.verses.at(-1)!.number,
-        },
-        language.scriptDirection,
-        hasDifferentMapping
-    );
+        return generateVerseFromReference(
+            {
+                verseId: 0,
+                book: singleBookText.bookName,
+                chapter: singleChapter.number,
+                verse: singleVerse.number,
+            },
+            language.scriptDirection,
+            hasDifferentMapping
+        );
+    } else {
+        return generateVerseFromReference(
+            {
+                startVerseId: 0,
+                startBook: bookTexts[0]!.bookName,
+                startChapter: bookTexts[0]!.chapters[0]!.number,
+                startVerse: bookTexts[0]!.chapters[0]!.verses[0]!.number,
+                endVerseId: 0,
+                endBook: bookTexts.at(-1)!.bookName,
+                endChapter: bookTexts.at(-1)!.chapters.at(-1)!.number,
+                endVerse: bookTexts.at(-1)!.chapters.at(-1)!.verses.at(-1)!.number,
+            },
+            language.scriptDirection,
+            hasDifferentMapping
+        );
+    }
 }
 
 function findMappingByVerseId(verseId: number, versificationMappings: VerseMapping[] | null): VerseMapping | undefined {

--- a/src/lib/components/references/bibleTextReferenceFetcher.ts
+++ b/src/lib/components/references/bibleTextReferenceFetcher.ts
@@ -162,7 +162,10 @@ export const fetchAndFormat = async (
                 }
             }
 
-            verseDisplayName = generateVerseRangeDisplayName(passageBookTexts, language, true);
+            verseDisplayName =
+                passageStartVerseId === passageEndVerseId
+                    ? generateSingleVerseDisplayName(passageBookTexts, language, true)
+                    : generateVerseRangeDisplayName(passageBookTexts, language, true);
         }
     } else {
         // if passage has no mapping, passage perfectly aligned

--- a/src/lib/components/references/bibleTextReferenceFetcher.ts
+++ b/src/lib/components/references/bibleTextReferenceFetcher.ts
@@ -186,7 +186,11 @@ export const fetchAndFormat = async (
                 return null;
             }
 
-            verseDisplayName = generateVerseRangeDisplayName(passageBookTexts, language, false);
+            // handle the case where verse 0 was requested in addition to only requesting verse 1 but verse 0 doesn't exist in the target Bible
+            verseDisplayName =
+                passageBookTexts.length === 1
+                    ? generateSingleVerseDisplayName(passageBookTexts, language, false)
+                    : generateVerseRangeDisplayName(passageBookTexts, language, false);
         }
     }
 

--- a/src/lib/components/references/bibleTextReferenceFetcher.ts
+++ b/src/lib/components/references/bibleTextReferenceFetcher.ts
@@ -95,7 +95,10 @@ export const fetchAndFormat = async (
                 }
             }
 
-            verseDisplayName = generateSingleVerseDisplayName(passageBookTexts, language, true);
+            verseDisplayName =
+                startVerseMapping!.targetVerses.length === 1
+                    ? generateSingleVerseDisplayName(passageBookTexts, language, true)
+                    : generateVerseRangeDisplayName(passageBookTexts, language, true);
         } else {
             // multiple vers passage with at least some mappings
             // ! any given VerseMapping.targetVerse in the mapping can be null.


### PR DESCRIPTION
Fixes verse reference display for the following scenarios:
* Single source verse with multiple target verses (fixes missing verse 68 in "Неемии 7:67*" reference in https://qa.admin.aquifer.bible/resources/385016)
* Multiple source verses that all map to one target verse (fixes "Псалтирь 10:1-1*" reference in https://qa.admin.aquifer.bible/resources/385017).
* Fetching verse 0 in addition to only verse 1 but verse 0 doesn't exist (fixes "Rev. 9:1-1" reference in https://qa.admin.aquifer.bible/resources/1434).