### PR TITLE
Set fallback Bible to 1 for fetching versification mappings.

### DIFF
--- a/src/lib/utils/bible-passage-fetcher.ts
+++ b/src/lib/utils/bible-passage-fetcher.ts
@@ -1,24 +1,15 @@
-import { fetchLanguageDefaultBible } from '$lib/utils/bibles-fetcher';
 import { fetchBibleBookTexts, type BibleBookTexts } from '$lib/utils/bible-book-fetcher';
 import { parseVerseId, type Verse } from './bible-passage-utils';
 
 export async function fetchBiblePassages(
     startVerseId: number,
     endVerseId: number,
-    languageId: number,
-    passedBibleId?: number
+    bibleId: number
 ): Promise<BibleBookTexts[]> {
     const start = parseVerseId(startVerseId);
     const end = parseVerseId(endVerseId);
     const spansMultipleBooks = start.bookId !== end.bookId;
-    let bibleId: number = passedBibleId ?? 1;
-
     const texts: BibleBookTexts[] = [];
-
-    if (!passedBibleId) {
-        const bible = await fetchLanguageDefaultBible(languageId);
-        bibleId = bible?.id ?? 1;
-    }
 
     for (let i = start.bookId; i <= end.bookId; i++) {
         let bookStart = start;

--- a/src/lib/utils/bible-versification-fetcher.ts
+++ b/src/lib/utils/bible-versification-fetcher.ts
@@ -2,7 +2,6 @@ import { log } from '$lib/logger';
 import type { VerseReference } from '$lib/types/resources';
 import { parseVerseId } from './bible-passage-utils';
 import { getFromApi } from './http-service';
-import { fetchLanguageDefaultBible } from './bibles-fetcher';
 
 export interface VersificationResponse {
     verseMappings: VerseMapping[];
@@ -17,20 +16,10 @@ export interface VerseMapping {
 export async function fetchBibleVersification(
     startVerseId: number,
     endVerseId: number,
-    languageId: number,
-    bibleId?: number
+    bibleId: number
 ): Promise<VerseMapping[] | null> {
     const start = parseVerseId(startVerseId);
     const end = parseVerseId(endVerseId);
-    bibleId = bibleId ?? 0;
-
-    if (bibleId === 0) {
-        const langDefaultBible = await fetchLanguageDefaultBible(languageId);
-        if (langDefaultBible) {
-            bibleId = langDefaultBible.id;
-        }
-    }
-
     const allMappings: VerseMapping[] = [];
 
     try {


### PR DESCRIPTION
This fixes a 400 when fetching versifications with Bible ID 0 by ensuring consistent Bible selection logic for both fetching Bible passage text and Bible versifications.

See also https://biblionexusworkspace.slack.com/archives/C0662HZ7RKM/p1742600035089939.