### PR TITLE
Fix alignment of filter checkboxes.

### DIFF
--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -149,15 +149,15 @@
             placeholder="Chapter (e.g. 2, 1-5)"
         />
         <div class={shouldShowNotApplicable ? 'flex flex-col space-y-2' : 'flex'}>
-            <div class="form-control flex justify-between">
-                <label class="label cursor-pointer py-0">
+            <div class="form-control flex w-full justify-between">
+                <label class="label flex w-full cursor-pointer justify-between py-0">
                     <span class="label-text text-xs">Show Only Published</span>
                     <input type="checkbox" bind:checked={isPublished} class="checkbox no-animation checkbox-xs ms-2" />
                 </label>
             </div>
             {#if shouldShowNotApplicable}
-                <div class="form-control flex justify-between">
-                    <label class="label cursor-pointer py-0">
+                <div class="form-control flex w-full justify-between">
+                    <label class="label flex w-full cursor-pointer justify-between py-0">
                         <span class="label-text text-xs">Show Only N/A</span>
                         <input
                             type="checkbox"


### PR DESCRIPTION
Puts back classes removed [here](https://github.com/BiblioNexusStudio/content-manager-web/pull/613/files#diff-903a8cfd9beda8c2f18acd1573fa6a7ed2d31b41af980671e906f03bc68d23c8L156-L157) which results in left justification of checkbox labels and right justification of checkboxes.