### PR TITLE
Fix asterisk display.

### DIFF
--- a/src/lib/components/references/BibleTextReference.svelte
+++ b/src/lib/components/references/BibleTextReference.svelte
@@ -47,7 +47,7 @@
             {/if}
             {#each text.chapters as chapter (chapter)}
                 {#if !bibleTextsReference.isSingleChapter}
-                    <div class="font-semibold" dir="auto">Chapter {chapter.number}</div>
+                    <div class="pt-4 font-semibold" dir="auto">Chapter {chapter.number}</div>
                 {/if}
                 {#each chapter.verses as verse (verse)}
                     <div dir="auto">


### PR DESCRIPTION
Fixes https://qa.admin.aquifer.bible/resources/385020 where `Psalms 11:1-7` in the ENG is mapping to `Psalms 11:1-7*` in the LS1910 due to ENG having verse 0 but LS1910 not having verse 0.

Before:
![image](https://github.com/user-attachments/assets/6f37039d-bbad-4017-8819-8ab3cad22de1)

After:
![image](https://github.com/user-attachments/assets/c782e925-893a-4d8e-8391-d7fed20f1dfe)

While I was in there I also improved the spacing when reading multiple chapters at once by adding padding over the "Chapter N" text (it was previously very difficult to quickly find the correct chapter in large blocks of text):
![image](https://github.com/user-attachments/assets/53b6d8ca-1878-48b2-81ce-1aea3e84c585)
