### PR TITLE
Allow choosing both source and target languages when creating a project.

### DIFF
--- a/src/routes/projects/new/+page.svelte
+++ b/src/routes/projects/new/+page.svelte
@@ -35,7 +35,7 @@
     });
 
     let isForAquiferization = $derived(
-        !!sourceLanguageId && !!targetLanguageId && sourceLanguageId === targetLanguageId
+        !isTranslatedChecked && !!sourceLanguageId && !!targetLanguageId && sourceLanguageId === targetLanguageId
     );
     let isAlreadyTranslated = $derived(!isForAquiferization && isTranslatedChecked);
 
@@ -203,6 +203,9 @@
                                 class="toggle me-0.5"
                                 bind:checked={isTranslatedChecked}
                                 disabled={isForAquiferization || selectedResourceIds.length > 0}
+                                onchange={() => {
+                                    targetLanguageId = null;
+                                }}
                             />
                         </label>
                     </div>

--- a/src/routes/projects/new/+page.svelte
+++ b/src/routes/projects/new/+page.svelte
@@ -41,7 +41,7 @@
 
     let canSave = $derived(
         !!title &&
-            !!sourceLanguageId &&
+            (isAlreadyTranslated || !!sourceLanguageId) &&
             !!targetLanguageId &&
             !!projectManagerUserId &&
             !!companyId &&
@@ -99,7 +99,9 @@
                     <input bind:value={title} class="input input-bordered input-sm w-full max-w-[50%]" />
                 </div>
                 <div class="flex flex-row items-center border-b p-2">
-                    <div class="text-md">Source Language <span class="text-error">*</span></div>
+                    <div class="text-md">
+                        {!isAlreadyTranslated ? 'Source ' : ''}Language <span class="text-error">*</span>
+                    </div>
                     <div class="grow"></div>
                     <Select
                         bind:value={sourceLanguageId}
@@ -107,7 +109,7 @@
                         disabled={selectedResourceIds.length > 0}
                         isNumber={true}
                         options={[
-                            { value: null, label: 'Select Source Language' },
+                            { value: null, label: 'Select ' + (!isAlreadyTranslated ? 'Source ' : '') + 'Language' },
                             ...(languages || []).map((l) => ({
                                 value: l.id,
                                 label: l.englishDisplay,
@@ -115,33 +117,35 @@
                         ]}
                     />
                 </div>
-                <div class="flex flex-row items-center border-b p-2">
-                    <div class="text-md">Target Language <span class="text-error">*</span></div>
-                    <div class="grow"></div>
-                    <Select
-                        bind:value={targetLanguageId}
-                        class="select select-bordered select-sm w-full max-w-[50%]"
-                        disabled={!sourceLanguageId || selectedResourceIds.length > 0}
-                        isNumber={true}
-                        options={[
-                            { value: null, label: 'Select Target Language' },
-                            ...(languages || [])
-                                // only allow English resource contents to be Aquiferized (for now)
-                                .filter(
-                                    (l) =>
-                                        l.id !== sourceLanguageId ||
-                                        (sourceLanguageId === l.id && l.iso6393Code === 'eng')
-                                )
-                                .map((l) => ({
-                                    value: l.id,
-                                    label:
-                                        l.id === sourceLanguageId
-                                            ? l.englishDisplay + ' (Aquiferize)'
-                                            : l.englishDisplay,
-                                })),
-                        ]}
-                    />
-                </div>
+                {#if !isAlreadyTranslated}
+                    <div class="flex flex-row items-center border-b p-2">
+                        <div class="text-md">Target Language <span class="text-error">*</span></div>
+                        <div class="grow"></div>
+                        <Select
+                            bind:value={targetLanguageId}
+                            class="select select-bordered select-sm w-full max-w-[50%]"
+                            disabled={(!isAlreadyTranslated && !sourceLanguageId) || selectedResourceIds.length > 0}
+                            isNumber={true}
+                            options={[
+                                { value: null, label: 'Select Target Language' },
+                                ...(languages || [])
+                                    // only allow English resource contents to be Aquiferized (for now)
+                                    .filter(
+                                        (l) =>
+                                            l.id !== sourceLanguageId ||
+                                            (sourceLanguageId === l.id && l.iso6393Code === 'eng')
+                                    )
+                                    .map((l) => ({
+                                        value: l.id,
+                                        label:
+                                            l.id === sourceLanguageId
+                                                ? l.englishDisplay + ' (Aquiferize)'
+                                                : l.englishDisplay,
+                                    })),
+                            ]}
+                        />
+                    </div>
+                {/if}
             </div>
             <div class="w-full">
                 <div class="flex flex-row items-center border-b p-2">
@@ -208,10 +212,10 @@
     </div>
     <div class="short:h-[30rem] flex flex-col overflow-hidden">
         <div class="text-lg font-bold">Add Content</div>
-        <!-- the key ensures we reset the project content selection when language changes -->
+        <!-- the key ensures we reset the project content selection when the selected languages or translation settings change -->
         {#key sourceLanguageId?.toString() + '-' + targetLanguageId?.toString() + '-' + isAlreadyTranslated.toString()}
             <ProjectContentSelector
-                disabled={!sourceLanguageId || !targetLanguageId}
+                disabled={!sourceLanguageId || (!isAlreadyTranslated && !targetLanguageId)}
                 {sourceLanguageId}
                 {targetLanguageId}
                 {data}

--- a/src/routes/projects/new/+page.svelte
+++ b/src/routes/projects/new/+page.svelte
@@ -41,8 +41,8 @@
 
     let canSave = $derived(
         !!title &&
-            (isAlreadyTranslated || !!sourceLanguageId) &&
-            !!targetLanguageId &&
+            !!sourceLanguageId &&
+            (isTranslatedChecked || !!targetLanguageId) &&
             !!projectManagerUserId &&
             !!companyId &&
             !!companyLeadUserId &&
@@ -100,7 +100,7 @@
                 </div>
                 <div class="flex flex-row items-center border-b p-2">
                     <div class="text-md">
-                        {!isAlreadyTranslated ? 'Source ' : ''}Language <span class="text-error">*</span>
+                        {!isTranslatedChecked ? 'Source ' : ''}Language <span class="text-error">*</span>
                     </div>
                     <div class="grow"></div>
                     <Select
@@ -109,7 +109,7 @@
                         disabled={selectedResourceIds.length > 0}
                         isNumber={true}
                         options={[
-                            { value: null, label: 'Select ' + (!isAlreadyTranslated ? 'Source ' : '') + 'Language' },
+                            { value: null, label: 'Select ' + (!isTranslatedChecked ? 'Source ' : '') + 'Language' },
                             ...(languages || []).map((l) => ({
                                 value: l.id,
                                 label: l.englishDisplay,
@@ -117,14 +117,14 @@
                         ]}
                     />
                 </div>
-                {#if !isAlreadyTranslated}
+                {#if !isTranslatedChecked}
                     <div class="flex flex-row items-center border-b p-2">
                         <div class="text-md">Target Language <span class="text-error">*</span></div>
                         <div class="grow"></div>
                         <Select
                             bind:value={targetLanguageId}
                             class="select select-bordered select-sm w-full max-w-[50%]"
-                            disabled={(!isAlreadyTranslated && !sourceLanguageId) || selectedResourceIds.length > 0}
+                            disabled={(!isTranslatedChecked && !sourceLanguageId) || selectedResourceIds.length > 0}
                             isNumber={true}
                             options={[
                                 { value: null, label: 'Select Target Language' },

--- a/src/routes/projects/new/+page.svelte
+++ b/src/routes/projects/new/+page.svelte
@@ -110,10 +110,13 @@
                         isNumber={true}
                         options={[
                             { value: null, label: 'Select ' + (!isTranslatedChecked ? 'Source ' : '') + 'Language' },
-                            ...(languages || []).map((l) => ({
-                                value: l.id,
-                                label: l.englishDisplay,
-                            })),
+                            ...(languages || [])
+                                // don't allow English resource contents to be put into an already translated project
+                                .filter((l) => !isTranslatedChecked || l.iso6393Code !== 'eng')
+                                .map((l) => ({
+                                    value: l.id,
+                                    label: l.englishDisplay,
+                                })),
                         ]}
                     />
                 </div>
@@ -129,7 +132,7 @@
                             options={[
                                 { value: null, label: 'Select Target Language' },
                                 ...(languages || [])
-                                    // only allow English resource contents to be Aquiferized (for now)
+                                    // only allow English resource contents to be Aquiferized
                                     .filter(
                                         (l) =>
                                             l.id !== sourceLanguageId ||
@@ -204,6 +207,7 @@
                                 bind:checked={isTranslatedChecked}
                                 disabled={isForAquiferization || selectedResourceIds.length > 0}
                                 onchange={() => {
+                                    sourceLanguageId = null;
                                     targetLanguageId = null;
                                 }}
                             />

--- a/src/routes/projects/new/+page.svelte
+++ b/src/routes/projects/new/+page.svelte
@@ -92,109 +92,116 @@
     <div class="mb-8 flex flex-col">
         <div class="w-full pb-2 text-lg font-bold">Basic Information</div>
         <div class="grid grid-cols-2 gap-4">
-            <div class="flex flex-row items-center border-b p-2">
-                <div class="text-md">Title <span class="text-error">*</span></div>
-                <div class="grow"></div>
-                <input bind:value={title} class="input input-bordered input-sm w-full max-w-[50%]" />
-            </div>
-            <div class="flex flex-row items-center border-b p-2">
-                <div class="text-md">Source Language <span class="text-error">*</span></div>
-                <div class="grow"></div>
-                <Select
-                    bind:value={sourceLanguageId}
-                    class="select select-bordered select-sm w-full max-w-[50%]"
-                    disabled={selectedResourceIds.length > 0}
-                    isNumber={true}
-                    options={[
-                        { value: null, label: 'Select Source Language' },
-                        ...(languages || []).map((l) => ({
-                            value: l.id,
-                            label: l.englishDisplay,
-                        })),
-                    ]}
-                />
-            </div>
-            <div class="flex flex-row items-center border-b p-2">
-                <div class="text-md">Target Language <span class="text-error">*</span></div>
-                <div class="grow"></div>
-                <Select
-                    bind:value={targetLanguageId}
-                    class="select select-bordered select-sm w-full max-w-[50%]"
-                    disabled={!sourceLanguageId || selectedResourceIds.length > 0}
-                    isNumber={true}
-                    options={[
-                        { value: null, label: 'Select Target Language' },
-                        ...(languages || [])
-                            // only allow English resources to be Aquiferized (for now)
-                            .filter(
-                                (l) =>
-                                    l.id !== sourceLanguageId || (sourceLanguageId === l.id && l.iso6393Code === 'eng')
-                            )
-                            .map((l) => ({
-                                value: l.id,
-                                label:
-                                    l.id === sourceLanguageId ? l.englishDisplay + ' (Aquiferize)' : l.englishDisplay,
-                            })),
-                    ]}
-                />
-            </div>
-            <div class="flex flex-row items-center border-b p-2">
-                <div class="text-md">Project Manager <span class="text-error">*</span></div>
-                <div class="grow"></div>
-                <Select
-                    bind:value={projectManagerUserId}
-                    class="select select-bordered select-sm w-full max-w-[50%]"
-                    isNumber={true}
-                    options={[
-                        { value: null, label: 'Select User' },
-                        ...(users || [])
-                            .filter((u) => u.role === UserRole.Publisher)
-                            .map((u) => ({ value: u.id, label: u.name })),
-                    ]}
-                />
-            </div>
-            <div class="flex flex-row items-center border-b p-2">
-                <div class="text-md">Company <span class="text-error">*</span></div>
-                <div class="grow"></div>
-                <Select
-                    bind:value={companyId}
-                    class="select select-bordered select-sm w-full max-w-[50%]"
-                    isNumber={true}
-                    options={[
-                        { value: null, label: 'Select Company' },
-                        ...(companies || [])
-                            .filter((c) => c.name !== 'N/A')
-                            .map((c) => ({ value: c.id, label: c.name })),
-                    ]}
-                />
-            </div>
-            <div class="flex flex-row items-center border-b p-2">
-                <div class="text-md">Company Lead <span class="text-error">*</span></div>
-                <div class="grow"></div>
-                <Select
-                    bind:value={companyLeadUserId}
-                    class="select select-bordered select-sm w-full max-w-[50%]"
-                    isNumber={true}
-                    options={[
-                        { value: null, label: 'Select User' },
-                        ...(users || [])
-                            .filter((u) => u.role === UserRole.Manager)
-                            .map((c) => ({ value: c.id, label: c.name })),
-                    ]}
-                />
-            </div>
-            <div class="flex flex-row items-center border-b p-2">
-                {#if !isForAquiferization}
-                    <div class="text-md">Create project from already translated items</div>
+            <div class="w-full">
+                <div class="flex flex-row items-center border-b p-2">
+                    <div class="text-md">Title <span class="text-error">*</span></div>
                     <div class="grow"></div>
-                    <label class="flex items-center">
-                        <input
-                            type="checkbox"
-                            class="toggle me-0.5"
-                            bind:checked={isTranslatedChecked}
-                            disabled={isForAquiferization || selectedResourceIds.length > 0}
-                        />
-                    </label>
+                    <input bind:value={title} class="input input-bordered input-sm w-full max-w-[50%]" />
+                </div>
+                <div class="flex flex-row items-center border-b p-2">
+                    <div class="text-md">Source Language <span class="text-error">*</span></div>
+                    <div class="grow"></div>
+                    <Select
+                        bind:value={sourceLanguageId}
+                        class="select select-bordered select-sm w-full max-w-[50%]"
+                        disabled={selectedResourceIds.length > 0}
+                        isNumber={true}
+                        options={[
+                            { value: null, label: 'Select Source Language' },
+                            ...(languages || []).map((l) => ({
+                                value: l.id,
+                                label: l.englishDisplay,
+                            })),
+                        ]}
+                    />
+                </div>
+                <div class="flex flex-row items-center border-b p-2">
+                    <div class="text-md">Target Language <span class="text-error">*</span></div>
+                    <div class="grow"></div>
+                    <Select
+                        bind:value={targetLanguageId}
+                        class="select select-bordered select-sm w-full max-w-[50%]"
+                        disabled={!sourceLanguageId || selectedResourceIds.length > 0}
+                        isNumber={true}
+                        options={[
+                            { value: null, label: 'Select Target Language' },
+                            ...(languages || [])
+                                // only allow English resources to be Aquiferized (for now)
+                                .filter(
+                                    (l) =>
+                                        l.id !== sourceLanguageId ||
+                                        (sourceLanguageId === l.id && l.iso6393Code === 'eng')
+                                )
+                                .map((l) => ({
+                                    value: l.id,
+                                    label:
+                                        l.id === sourceLanguageId
+                                            ? l.englishDisplay + ' (Aquiferize)'
+                                            : l.englishDisplay,
+                                })),
+                        ]}
+                    />
+                </div>
+            </div>
+            <div class="w-full">
+                <div class="flex flex-row items-center border-b p-2">
+                    <div class="text-md">Project Manager <span class="text-error">*</span></div>
+                    <div class="grow"></div>
+                    <Select
+                        bind:value={projectManagerUserId}
+                        class="select select-bordered select-sm w-full max-w-[50%]"
+                        isNumber={true}
+                        options={[
+                            { value: null, label: 'Select User' },
+                            ...(users || [])
+                                .filter((u) => u.role === UserRole.Publisher)
+                                .map((u) => ({ value: u.id, label: u.name })),
+                        ]}
+                    />
+                </div>
+                <div class="flex flex-row items-center border-b p-2">
+                    <div class="text-md">Company <span class="text-error">*</span></div>
+                    <div class="grow"></div>
+                    <Select
+                        bind:value={companyId}
+                        class="select select-bordered select-sm w-full max-w-[50%]"
+                        isNumber={true}
+                        options={[
+                            { value: null, label: 'Select Company' },
+                            ...(companies || [])
+                                .filter((c) => c.name !== 'N/A')
+                                .map((c) => ({ value: c.id, label: c.name })),
+                        ]}
+                    />
+                </div>
+                <div class="flex flex-row items-center border-b p-2">
+                    <div class="text-md">Company Lead <span class="text-error">*</span></div>
+                    <div class="grow"></div>
+                    <Select
+                        bind:value={companyLeadUserId}
+                        class="select select-bordered select-sm w-full max-w-[50%]"
+                        isNumber={true}
+                        options={[
+                            { value: null, label: 'Select User' },
+                            ...(users || [])
+                                .filter((u) => u.role === UserRole.Manager)
+                                .map((c) => ({ value: c.id, label: c.name })),
+                        ]}
+                    />
+                </div>
+                {#if !isForAquiferization}
+                    <div class="flex flex-row items-center border-b p-2">
+                        <div class="text-md">Create project from already translated items</div>
+                        <div class="grow"></div>
+                        <label class="flex items-center">
+                            <input
+                                type="checkbox"
+                                class="toggle me-0.5"
+                                bind:checked={isTranslatedChecked}
+                                disabled={isForAquiferization || selectedResourceIds.length > 0}
+                            />
+                        </label>
+                    </div>
                 {/if}
             </div>
         </div>

--- a/src/routes/projects/new/+page.svelte
+++ b/src/routes/projects/new/+page.svelte
@@ -126,7 +126,7 @@
                         options={[
                             { value: null, label: 'Select Target Language' },
                             ...(languages || [])
-                                // only allow English resources to be Aquiferized (for now)
+                                // only allow English resource contents to be Aquiferized (for now)
                                 .filter(
                                     (l) =>
                                         l.id !== sourceLanguageId ||
@@ -209,7 +209,7 @@
     <div class="short:h-[30rem] flex flex-col overflow-hidden">
         <div class="text-lg font-bold">Add Content</div>
         <!-- the key ensures we reset the project content selection when language changes -->
-        {#key sourceLanguageId?.toString() + '-' + sourceLanguageId?.toString() + '-' + isAlreadyTranslated.toString()}
+        {#key sourceLanguageId?.toString() + '-' + targetLanguageId?.toString() + '-' + isAlreadyTranslated.toString()}
             <ProjectContentSelector
                 disabled={!sourceLanguageId || !targetLanguageId}
                 {sourceLanguageId}

--- a/src/routes/projects/new/+page.svelte
+++ b/src/routes/projects/new/+page.svelte
@@ -19,7 +19,7 @@
     const { languages, users, companies } = data;
 
     let title = $state('');
-    let sourceLanguageId: number | null = $state(null);
+    let sourceLanguageId: number | null = $state((languages || []).find((l) => l.iso6393Code === 'eng')?.id ?? null);
     let targetLanguageId: number | null = $state(null);
     let projectManagerUserId: number | null = $state(null);
     let companyId: number | null = $state(null);

--- a/src/routes/projects/new/ProjectContentSelector.svelte
+++ b/src/routes/projects/new/ProjectContentSelector.svelte
@@ -106,7 +106,7 @@
                         `/resources/unaquiferized?${searchParams.toString()}`
                     )) ?? [];
             } else if (isAlreadyTranslated) {
-                !!targetLanguageId && searchParams.set('languageId', targetLanguageId.toString());
+                !!sourceLanguageId && searchParams.set('languageId', sourceLanguageId.toString());
                 fetchedContentForLeft =
                     (await getFromApi<ResourceContentForSelection[]>(
                         `/resources/translated?${searchParams.toString()}`

--- a/src/routes/projects/new/ProjectContentSelector.svelte
+++ b/src/routes/projects/new/ProjectContentSelector.svelte
@@ -14,7 +14,8 @@
     interface Props {
         data: PageData;
         disabled: boolean;
-        languageId: number | null;
+        sourceLanguageId: number | null;
+        targetLanguageId: number | null;
         finalizedResourceIds: number[];
         isForAquiferization: boolean;
         isAlreadyTranslated: boolean;
@@ -23,7 +24,8 @@
     let {
         data,
         disabled,
-        languageId,
+        sourceLanguageId,
+        targetLanguageId,
         finalizedResourceIds = $bindable(),
         isForAquiferization,
         isAlreadyTranslated,
@@ -94,18 +96,20 @@
 
         try {
             if (isForAquiferization) {
+                !!targetLanguageId && searchParams.set('languageId', targetLanguageId.toString());
                 fetchedContentForLeft =
                     (await getFromApi<ResourceContentForSelection[]>(
                         `/resources/unaquiferized?${searchParams.toString()}`
                     )) ?? [];
             } else if (isAlreadyTranslated) {
-                !!languageId && searchParams.set('languageId', languageId.toString());
+                !!targetLanguageId && searchParams.set('languageId', targetLanguageId.toString());
                 fetchedContentForLeft =
                     (await getFromApi<ResourceContentForSelection[]>(
                         `/resources/translated?${searchParams.toString()}`
                     )) ?? [];
             } else {
-                !!languageId && searchParams.set('languageId', languageId.toString());
+                !!sourceLanguageId && searchParams.set('sourceLanguageId', sourceLanguageId.toString());
+                !!targetLanguageId && searchParams.set('targetLanguageId', targetLanguageId.toString());
                 fetchedContentForLeft =
                     (await getFromApi<ResourceContentForSelection[]>(
                         `/resources/untranslated?${searchParams.toString()}`

--- a/src/routes/projects/new/ProjectContentSelector.svelte
+++ b/src/routes/projects/new/ProjectContentSelector.svelte
@@ -49,7 +49,11 @@
     let showingAquiferizeEditorReviewModal = $state(false);
 
     let chapters = $derived(
-        parseNumbersListFromString(chaptersString, 1, bibleBooks?.find((b) => b.code === bookCode)?.totalChapters ?? 0)
+        parseNumbersListFromString(
+            chaptersString ? chaptersString : 'all',
+            1,
+            bibleBooks?.find((b) => b.code === bookCode)?.totalChapters ?? 0
+        )
     );
 
     $effect(() => {


### PR DESCRIPTION
See also https://github.com/BiblioNexusStudio/aquifer-server/pull/737.

In addition to the requirements on BIB-906 I did a few extra things:
* Allow searching for project resource contents without specifying chapters (defaults to "all" when you click search).
* Update code to allow for future Aquiferization of non-English resource contents.  It's still gated to English-only on both the front-end and back-end but turning it on for other languages will be as simple as removing one `filter()` call.
* When "Create project from already translated items" is true then don't display English in the language dropdown (the back-end errors if you pass English).