### PR TITLE
expand layout onError to log all available error info

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -115,7 +115,26 @@
 
     function onError(event: Event) {
         if ('error' in event) {
-            log.exception(event.error);
+            const errorEvent = event as ErrorEvent;
+            let logString = `${errorEvent.error}`;
+
+            if (errorEvent.message) {
+                logString += `, Message: ${errorEvent.message}`;
+            }
+
+            if (errorEvent.filename) {
+                logString += `, file: ${errorEvent.filename}`;
+            }
+
+            if (errorEvent.lineno >= 0) {
+                logString += `, line: ${errorEvent.lineno}`;
+            }
+
+            if (errorEvent.colno >= 0) {
+                logString += `, column: ${errorEvent.colno}`;
+            }
+
+            log.exception(logString);
         }
     }
 


### PR DESCRIPTION
When catching an unhandled error, we are only logging the error which can be cryptic at times. In an attempt to gain more insight into these errors, I've expanded the `onError` fn in the `+layout.svelte` file to log all parameters available from the error event.